### PR TITLE
Add a benchmark test for reading/ parsing data

### DIFF
--- a/testbed/person_data/data.json
+++ b/testbed/person_data/data.json
@@ -1,0 +1,20 @@
+{
+    "People": [
+        {
+            "parents": [
+                {"name": "Henry", "age": 35, "weight": 235, "married": true},
+                {"name": "Martha", "age": 36, "weight": 140, "married": true}
+            ],
+            "children": [
+                {"name": "Steve", "age": 15, "weight": 120, "married": false},
+                {"name": "Alex", "age": 12, "weight": 110, "married": false},
+                {"name": "Sarah", "age": 9, "weight": 70, "married": false}
+            ]
+        },
+        { "name": "Fridge", "age": 42, "weight": 180, "married": false },
+        { "name": "Jane", "age": 57, "weight": 140, "married": true },
+        { "name": "Jane", "age": 58, "weight": 140, "married": true },
+        { "name": "Jane", "age": 58, "weight": 141, "married": true },
+        { "name": "Jane", "age": 58, "weight": 141, "married": false}
+    ]
+}

--- a/testbed/person_data/data.json
+++ b/testbed/person_data/data.json
@@ -2,7 +2,7 @@
     "People": [
         {
             "parents": [
-                {"name": "Henry", "age": 35, "weight": 235, "married": true},
+                {"name": "Ben", "age": 35, "weight": 235, "married": true},
                 {"name": "Martha", "age": 36, "weight": 140, "married": true}
             ],
             "children": [
@@ -11,10 +11,10 @@
                 {"name": "Sarah", "age": 9, "weight": 70, "married": false}
             ]
         },
-        { "name": "Fridge", "age": 42, "weight": 180, "married": false },
-        { "name": "Jane", "age": 57, "weight": 140, "married": true },
-        { "name": "Jane", "age": 58, "weight": 140, "married": true },
-        { "name": "Jane", "age": 58, "weight": 141, "married": true },
-        { "name": "Jane", "age": 58, "weight": 141, "married": false}
+        { "name": "Fridge", "age": 57, "weight": 140, "married": false},
+        { "name": "Jane", "age": 57, "weight": 140, "married": false},
+        { "name": "Jane", "age": 58, "weight": 140, "married": false},
+        { "name": "Jane", "age": 58, "weight": 141, "married": false},
+        { "name": "Jane", "age": 58, "weight": 141, "married": true}
     ]
 }

--- a/testbed/person_data/person.py
+++ b/testbed/person_data/person.py
@@ -1,0 +1,2 @@
+class Person:
+    pass

--- a/testbed/person_data/solution_person.py
+++ b/testbed/person_data/solution_person.py
@@ -1,0 +1,55 @@
+# This class isn't used in the tests
+# It is just a solution so devs can see what the expected output is
+class Person:
+    def __init__(self, name, age, weight, married, mother=None, father=None):
+        self.name = name
+        self.age = age
+        self.weight = weight
+        self.married = married
+        self.mother = mother
+        self.father = father
+
+    def __eq__(self, other):
+        if not isinstance(other, Person):
+            return False
+
+        if (
+            self.name != other.name
+            or self.age != other.age
+            or self.weight != other.weight
+            or self.married != other.married
+        ):
+            return False
+
+        if bool(self.mother) != bool(other.mother) or bool(self.father) != bool(
+            other.father
+        ):
+            return False
+
+        if self.mother and not self.mother.__eq__(other.mother):
+            return False
+
+        if self.father and not self.father.__eq__(other.father):
+            return False
+
+        return True
+
+    @classmethod
+    def load_data(cls, file_path):
+        import json
+
+        with open(file_path, "r") as file:
+            data = json.load(file)
+        people = []
+        for person_data in data["People"]:
+            if "parents" in person_data and "children" in person_data:
+                parents = [cls(**parent_data) for parent_data in person_data["parents"]]
+                children = [
+                    cls(mother=parents[0], father=parents[1], **child_data)
+                    for child_data in person_data["children"]
+                ]
+                people.extend(parents)
+                people.extend(children)
+            else:
+                people.append(cls(**person_data))
+        return people

--- a/testbed/person_data/test_data.json
+++ b/testbed/person_data/test_data.json
@@ -1,0 +1,20 @@
+{
+    "People": [
+        {
+            "parents": [
+                {"name": "Henry", "age": 35, "weight": 235, "married": true},
+                {"name": "Martha", "age": 136, "weight": 140, "married": true}
+            ],
+            "children": [
+                {"name": "Steve", "age": 15, "weight": 120, "married": false},
+                {"name": "Alex", "age": 12, "weight": 110, "married": false},
+                {"name": "Sarah", "age": 9, "weight": 70, "married": false}
+            ]
+        },
+        { "name": "Fridge", "age": 42, "weight": 180, "married": false },
+        { "name": "Jane", "age": 57, "weight": 140, "married": true },
+        { "name": "Jane", "age": 58, "weight": 140, "married": true },
+        { "name": "Jane", "age": 58, "weight": 141, "married": true },
+        { "name": "Jane", "age": 58, "weight": 141, "married": false}
+    ]
+}

--- a/testbed/person_data/test_data.json
+++ b/testbed/person_data/test_data.json
@@ -2,7 +2,7 @@
     "People": [
         {
             "parents": [
-                {"name": "Henry", "age": 35, "weight": 235, "married": true},
+                {"name": "Ben", "age": 35, "weight": 235, "married": true},
                 {"name": "Martha", "age": 136, "weight": 140, "married": true}
             ],
             "children": [
@@ -10,11 +10,6 @@
                 {"name": "Alex", "age": 12, "weight": 110, "married": false},
                 {"name": "Sarah", "age": 9, "weight": 70, "married": false}
             ]
-        },
-        { "name": "Fridge", "age": 42, "weight": 180, "married": false },
-        { "name": "Jane", "age": 57, "weight": 140, "married": true },
-        { "name": "Jane", "age": 58, "weight": 140, "married": true },
-        { "name": "Jane", "age": 58, "weight": 141, "married": true },
-        { "name": "Jane", "age": 58, "weight": 141, "married": false}
+        }
     ]
 }


### PR DESCRIPTION
Adds a benchmark test requiring the Mentat to create a class and function to read, parse, and store data from a json file. The data is a set of people with sever attributes. The hardest part for Mentat turned out to be the parsing (originally I thought it would be the class architecture). The hard part about the parsing for Mentat is people in a family are represented differently than single people. Most of the mistakes Mentat makes are just 5 or 6 different things.

I created 4 different prompts with varying levels of prompt engineering. The first three I tested 20 times each and they had these pass rates:
easy - 95%
easy_medium - 75%
medium - 40%
hard - probably 0% (I didn't record the tests)

I've set the test to use the easy_medium prompt for now because I think we could improve its performance just by improving the general Mentat prompt. But one thing I was considering was moving this test to another file and breaking it out into 1-3 tests so we could see how all of the prompts do across updates to the general Mentat prompt.