### PR TITLE
Separate Core Logic from Terminal Interface

### DIFF
--- a/concept2.py
+++ b/concept2.py
@@ -1,0 +1,92 @@
+import asyncio
+
+
+# --------------------------
+# UI Interface (e.g. terminal, vscode)
+# --------------------------
+class MentatInterface:
+    # should be implemented by subclasses
+    def display(self, content, color=None, end="\n"):
+        pass
+
+    # should be implemented by subclasses
+    async def get_user_input(self, prompt=None, options=None):
+        pass
+
+    # convenience function
+    async def ask_yes_no(self, prompt=None):
+        return (await self.get_user_input(prompt, options=["y", "n"])).lower() == "y"
+
+
+class TerminalMentatInterface(MentatInterface):
+    """Used to communicate with the terminal"""
+
+    # --------------------
+    # Methods called by VSCode
+    # --------------------
+
+    pass
+
+    # --------------------
+    # Methods called by Mentat
+    # --------------------
+
+    # used for all output, streaming or not
+    def display(self, content, color=None, end="\n"):
+        print(content, end=end, flush=True)
+
+    async def get_user_input(self, prompt=None, options=None):
+        while True:
+            if prompt is not None:
+                self.display(f"{prompt} ({'/'.join(options)})")
+            user_input = await asyncio.get_event_loop().run_in_executor(None, input)
+            if options is None:
+                return user_input
+            elif user_input.lower() in options:
+                return user_input
+            else:
+                self.display("Invalid response")
+
+
+class VSCodeInterface(MentatInterface):
+    pass
+
+
+# --------------------------
+# Mentat Run Function
+# --------------------------
+async def run_mentat(interface):
+    interface.display("Welcome to Mentat!\nWhat can I do for you?")
+    while True:
+        prompt = await interface.get_user_input()
+        await get_llm_response(interface, prompt)
+
+
+# --------------------------
+# External Methods (e.g.)
+# --------------------------
+async def get_llm_response(interface, prompt: str):
+    # Stream a response:
+    # def interrupt_callback():
+    #     runner.print("Terminating Async Process")  # e.g. The openai stream
+
+    # stream_handler, done = await runner.initialize_stream(interrupt_callback)
+    message = f"Ok, I'll {prompt}.\n"
+    for char in message:
+        interface.display(char, end="")
+        await asyncio.sleep(0.05)
+    # await done()
+
+    # Get yes/no confirmation
+    if await interface.ask_yes_no("Apply these changes?"):
+        interface.display("Applying changes")
+    else:
+        interface.display("Not applying changes")
+    interface.display("What else can I do for you?")
+
+
+# --------------------------
+# Set up interface, start Mentat
+# --------------------------
+interface = TerminalMentatInterface()
+asyncio.run(run_mentat(interface))

--- a/concept2.py
+++ b/concept2.py
@@ -1,3 +1,4 @@
+import sys
 import asyncio
 
 
@@ -14,8 +15,8 @@ class MentatInterface:
         pass
 
     # convenience function
-    async def ask_yes_no(self, prompt=None):
-        return (await self.get_user_input(prompt, options=["y", "n"])).lower() == "y"
+    def ask_yes_no(self, prompt=None):
+        return self.get_user_input(prompt, options=["y", "n"]).lower() == "y"
 
 
 class TerminalMentatInterface(MentatInterface):
@@ -35,11 +36,11 @@ class TerminalMentatInterface(MentatInterface):
     def display(self, content, color=None, end="\n"):
         print(content, end=end, flush=True)
 
-    async def get_user_input(self, prompt=None, options=None):
+    def get_user_input(self, prompt=None, options=None):
         while True:
             if prompt is not None:
                 self.display(f"{prompt} ({'/'.join(options)})")
-            user_input = await asyncio.get_event_loop().run_in_executor(None, input)
+            user_input = input()
             if options is None:
                 return user_input
             elif user_input.lower() in options:
@@ -49,17 +50,44 @@ class TerminalMentatInterface(MentatInterface):
 
 
 class VSCodeInterface(MentatInterface):
-    pass
+    # used for all output, streaming or not
+    def display(self, content, color=None, end="\n"):
+        print(content, end=end, flush=True)
+
+    def get_user_input(self, prompt=None, options=None):
+        while True:
+            if prompt is not None:
+                self.display(f"{prompt} ({'/'.join(options)})")
+            self.display('@@user_input')
+            user_input = input()
+            if options is None:
+                return user_input
+            elif user_input.lower() in options:
+                return user_input
+            else:
+                self.display("Invalid response")
 
 
 # --------------------------
 # Mentat Run Function
 # --------------------------
-async def run_mentat(interface):
+def run_mentat(interface):
     interface.display("Welcome to Mentat!\nWhat can I do for you?")
     while True:
-        prompt = await interface.get_user_input()
-        await get_llm_response(interface, prompt)
+        # User control: interrupt means quit
+        try:
+            prompt = interface.get_user_input()
+        except KeyboardInterrupt: 
+            print('Closing Mentat')
+            break
+        # Mentat control: interrupt means stop and go back to user input
+        try:
+            asyncio.run(get_llm_response(interface, prompt))
+            # When get_llm_response calls ask_yes_no, it happens inside of this loop,
+            # so even though control flow is back to the user, Ctrl-c is caught below.
+        except KeyboardInterrupt:
+            interface.display("")
+            interface.display("Interrupted! Let's try again. What can I do for you?")
 
 
 # --------------------------
@@ -78,7 +106,7 @@ async def get_llm_response(interface, prompt: str):
     # await done()
 
     # Get yes/no confirmation
-    if await interface.ask_yes_no("Apply these changes?"):
+    if interface.ask_yes_no("Apply these changes?"):
         interface.display("Applying changes")
     else:
         interface.display("Not applying changes")
@@ -88,5 +116,16 @@ async def get_llm_response(interface, prompt: str):
 # --------------------------
 # Set up interface, start Mentat
 # --------------------------
-interface = TerminalMentatInterface()
-asyncio.run(run_mentat(interface))
+if __name__ == "__main__":
+    interface_type = "terminal"
+    args = sys.argv[1:]
+    for i, arg in enumerate(args):
+        if arg in ["--interface", "-i"] and i + 1 < len(args):
+            if args[i + 1] == "vscode":
+                interface_type = "vscode"
+
+    if interface_type == "vscode":
+        interface = VSCodeInterface()
+    else:
+        interface = TerminalMentatInterface()
+    run_mentat(interface)

--- a/concept2_runner.py
+++ b/concept2_runner.py
@@ -1,0 +1,40 @@
+import subprocess
+
+class Runner:
+    def __init__(self):
+        self.process = subprocess.Popen(["python3", "concept2.py", "-i", "vscode"],
+                                        stdin=subprocess.PIPE,
+                                        stdout=subprocess.PIPE,
+                                        text=True)
+        self.get_output()
+        
+    def user_input(self, input_str):
+        self.process.stdin.write(input_str + '\n')
+        self.process.stdin.flush()
+        
+    def get_output(self):
+        try:
+            while True:
+                response = self.process.stdout.readline().strip()
+                if not response:
+                    break
+                elif response == '@@user_input':
+                    break
+                else:
+                    print(response)
+        except KeyboardInterrupt:
+            # Forward keyboardInterrupt to the subprocess
+            # This isn't working quite right, but it's a stand-in for calling 'interrupt'.
+            self.process.send_signal(2)
+            self.get_output()
+
+    def get_response(self, prompt):
+        self.user_input(prompt)
+        self.get_output()
+
+"""
+Run this in a terminal, Jupyter, etc:
+>>> from concept2_runner import Runner
+>>> runner = Runner()
+>>> runner.get_response('Hello')
+"""

--- a/concept3.py
+++ b/concept3.py
@@ -1,0 +1,108 @@
+import sys
+from prompt_toolkit import PromptSession
+import signal
+import asyncio
+
+
+class MentatInterrupt(Exception):
+    pass
+
+
+class MentatInterface:
+    # should be implemented by subclasses
+    def display(self, content, color=None, end="\n"):
+        pass
+
+    # should be implemented by subclasses
+    async def get_user_input(self, prompt=None, options=None):
+        pass
+
+    # convenience function
+    async def ask_yes_no(self, prompt=None):
+        return (await self.get_user_input(prompt, options=["y", "n"])).lower() == "y"
+
+
+class TerminalMentatInterface(MentatInterface):
+    """Used to communicate with the terminal"""
+
+    def __init__(self):
+        self.session = PromptSession()
+
+    def display(self, content, color=None, end="\n"):
+        print(content, end=end, flush=True)
+        global sigint
+        if sigint:
+            sigint = False
+            raise MentatInterrupt()
+
+    async def get_user_input(self, prompt=None, options=None):
+        while True:
+            if prompt is not None:
+                self.display(f"{prompt} ({'/'.join(options)})")
+
+            user_input =  await self.session.prompt_async()
+
+            if options is None:
+                return user_input
+            elif user_input.lower() in options:
+                return user_input
+            else:
+                self.display("Invalid response")
+
+
+async def run_mentat(interface):
+    for i in range(5):
+        print(i)
+        await asyncio.sleep(1)
+
+    try:
+        interface.display("Welcome to Mentat!\nWhat can I do for you?")
+        while True:
+            prompt = await interface.get_user_input()
+            await get_llm_response(interface, prompt)
+    except MentatInterrupt:
+        print('Closing Mentat')
+
+async def get_llm_response(interface, prompt: str):
+    message = f"Ok, I'll {prompt}.\n"
+    try:
+        for char in message:
+            interface.display(char, end="")
+            await asyncio.sleep(0.05)
+    except MentatInterrupt:
+        print("\nUser interrupted stream\n")
+
+    # Get yes/no confirmation
+    if await interface.ask_yes_no("Apply these changes?"):
+        interface.display("Applying changes")
+    else:
+        interface.display("Not applying changes")
+    interface.display("What else can I do for you?")
+
+sigint = False
+
+def signal_handler():
+    print("### SIGINT ###")
+    global sigint
+    sigint = True
+
+class AsyncController:
+
+    def __init__(self):
+        self.loop = asyncio.get_event_loop()
+        self.loop.add_signal_handler(signal.SIGINT, signal_handler)
+
+    def start_mentat_with_interface(self, interface):
+        print("starting!")
+        self.loop.run_until_complete(run_mentat(interface))
+        print("done!")
+
+
+if __name__ == "__main__":
+    ac = AsyncController()
+
+    interface = TerminalMentatInterface()
+    ac.start_mentat_with_interface(interface)
+
+
+

--- a/concept4/core.py
+++ b/concept4/core.py
@@ -1,0 +1,158 @@
+import asyncio
+import logging
+import signal
+from dataclasses import dataclass
+from typing import Any, Literal, Set
+
+logging.basicConfig(level=logging.INFO)
+logger = logging.getLogger()
+
+
+@dataclass
+class Completion:
+    source: Literal["syntax"] | Literal["command"]
+    data: str
+
+
+class MentatCompleter:
+    fake_completions = [
+        Completion(source="syntax", data="these"),
+        Completion(source="syntax", data="are"),
+        Completion(source="syntax", data="fake"),
+        Completion(source="syntax", data="completions"),
+        Completion(source="command", data="/help"),
+        Completion(source="command", data="/add"),
+    ]
+
+    def __init__(self):
+        ...
+
+    async def get_completions(self, text: str):
+        completions = []
+        for completion in self.fake_completions:
+            if completion.data.startswith(text.lower()):
+                completions.append(completion)
+        return completions
+
+
+class RpcServer:
+    """A JSON RPC server that sends and receives data.
+
+    See https://github.com/morph-labs/rift/blob/350a4195077ec2d1ec9b415a19afb6d84c8c69f7/rift-engine/rift/rpc/jsonrpc.py
+    """
+
+    async def serve(self):
+        """Open a TCP connection with a client.
+
+        This is an infinitely running loop that:
+        - routes requests from the client to RPC methods `MentatEngine` exposes
+        - sends responses to the client
+        """
+
+    async def _on_startup(self):
+        ...
+
+    async def _on_shutdown(self):
+        ...
+
+    async def _send(self, wait_for_response: bool = False):
+        """Send a request to the client"""
+
+    async def _recv(self):
+        """Receive a request from the client and route to RPC methods"""
+
+
+class MentatEngine:
+    """Manages all processes."""
+
+    def __init__(self, with_rpc: bool = False):
+        self.server = RpcServer() if with_rpc else None
+
+        self._should_exit = False
+        self._force_exit = False
+        self._tasks: Set[asyncio.Task] = set()
+
+        self.completer = MentatCompleter()
+
+    ### rpc-exposed methods (terminal client can call these directly)
+
+    async def on_connect(self):
+        """Sets up an RPC connection with a client"""
+        ...
+
+    async def disconnect(self):
+        """Closes an RPC connection with a client"""
+        ...
+
+    async def restart(self):
+        """Restart the MentatEngine and RPC server"""
+        ...
+
+    async def shutdown(self):
+        """Shutdown the MentatEngine and RPC server"""
+        ...
+
+    async def create_conversation_message(self):
+        ...
+
+    ### lifecycle methods
+
+    async def heartbeat(self):
+        while True:
+            logger.info("heartbeat")
+            await asyncio.sleep(3)
+
+    def _handle_exit(self):
+        if self._should_exit:
+            self._force_exit = True
+        else:
+            self._should_exit = True
+
+    def _init_signal_handlers(self):
+        loop = asyncio.get_event_loop()
+        loop.add_signal_handler(signal.SIGINT, self._handle_exit)
+        loop.add_signal_handler(signal.SIGTERM, self._handle_exit)
+
+    async def _startup(self):
+        logger.info("Starting Engine...")
+        heahtheck_task = asyncio.create_task(self.heartbeat())
+        self._tasks.add(heahtheck_task)
+
+    async def _main_loop(self):
+        logger.info("Running Engine...")
+
+        counter = 0
+        while not self._should_exit:
+            counter += 1
+            counter = counter % 86400
+            await asyncio.sleep(0.1)
+
+    async def _shutdown(self):
+        logger.info("Shutting Engine down...")
+
+        for task in self._tasks:
+            task.cancel()
+        logger.info("Waiting for Jobs to finish. (CTRL+C to force quit)")
+        while not self._force_exit:
+            if all([task.cancelled() for task in self._tasks]):
+                break
+            await asyncio.sleep(0.1)
+
+        if self._force_exit:
+            logger.debug("Force exiting.")
+
+        logger.info("Engine has stopped")
+
+    async def _run(self):
+        self._init_signal_handlers()
+        await self._startup()
+        await self._main_loop()
+        await self._shutdown()
+
+    def run(self):
+        asyncio.run(self._run())
+
+
+if __name__ == "__main__":
+    mentat_engine = MentatEngine()
+    mentat_engine.run()

--- a/concept4/terminal_client.py
+++ b/concept4/terminal_client.py
@@ -1,0 +1,63 @@
+import asyncio
+import logging
+
+from core import MentatEngine
+from prompt_toolkit import PromptSession
+from prompt_toolkit.completion import Completion, WordCompleter
+
+logging.basicConfig(level=logging.INFO)
+logger = logging.getLogger()
+
+
+class TerminalCompleter(WordCompleter):
+    def __init__(self, engine: MentatEngine):
+        self.engine = engine
+
+    async def get_completions_async(self, document, complete_event):
+        document_words = document.text_before_cursor.split()
+        if not document_words:
+            return
+        last_word = document_words[-1]
+        completions = await self.engine.completer.get_completions(last_word)
+        for completion in completions:
+            yield Completion(completion.data, display=completion.data)
+
+
+class TerminalClient:
+    def __init__(self):
+        self._engine = MentatEngine()
+        self._engine_task = None
+
+        self._session = PromptSession(completer=TerminalCompleter(self._engine))
+
+    async def get_user_input(self):
+        if self._session is None:
+            raise Exception("TerminalClient not started")
+
+        print("input something:\n")
+        user_input = await self._session.prompt_async()
+        print("User input:", user_input)
+
+    async def _run(self):
+        try:
+            self._engine_task = asyncio.create_task(self._engine._run())
+            while True:
+                await self.get_user_input()
+        except KeyboardInterrupt:
+            print("keyboard interrupt")
+        except Exception as e:
+            print("unhandled exception:", e)
+        finally:
+            if isinstance(self._engine_task, asyncio.Task):
+                self._engine._should_exit = True
+                assert self._engine_task
+                await self._engine_task
+                self._engine_task = None
+
+    def run(self):
+        asyncio.run(self._run())
+
+
+if __name__ == "__main__":
+    terminal_client = TerminalClient()
+    terminal_client.run()

--- a/mentat/app.py
+++ b/mentat/app.py
@@ -12,6 +12,7 @@ from .config_manager import ConfigManager, mentat_dir_path
 from .conversation import Conversation
 from .errors import MentatError, UserError
 from .git_handler import get_shared_git_root_for_paths
+from .interface import InterfaceType, get_interface, initialize_mentat_interface
 from .llm_api import CostTracker, setup_api_key
 from .logging_config import setup_logging
 from .user_input_manager import UserInputManager, UserQuitInterrupt
@@ -37,6 +38,9 @@ def run_cli():
     args = parser.parse_args()
     paths = args.paths
     exclude_paths = args.exclude
+
+    initialize_mentat_interface(InterfaceType.Terminal)
+
     run(expand_paths(paths), expand_paths(exclude_paths))
 
 
@@ -98,7 +102,9 @@ def loop(
     )
     conv = Conversation(config, cost_tracker, code_file_manager)
 
-    cprint("Type 'q' or use Ctrl-C to quit at any time.\n", color="cyan")
+    get_interface().interact(
+        "Type 'q' or use Ctrl-C to quit at any time.\n", color="cyan"
+    )
     cprint("What can I do for you?", color="light_blue")
     need_user_request = True
     while True:

--- a/mentat/app.py
+++ b/mentat/app.py
@@ -12,7 +12,7 @@ from .config_manager import ConfigManager, mentat_dir_path
 from .conversation import Conversation
 from .errors import MentatError, UserError
 from .git_handler import get_shared_git_root_for_paths
-from .interface import InterfaceType, get_interface, initialize_mentat_interface
+from .interface import InterfaceType, initialize_mentat_interface, output
 from .llm_api import CostTracker, setup_api_key
 from .logging_config import setup_logging
 from .user_input_manager import UserInputManager, UserQuitInterrupt
@@ -102,9 +102,7 @@ def loop(
     )
     conv = Conversation(config, cost_tracker, code_file_manager)
 
-    get_interface().interact(
-        "Type 'q' or use Ctrl-C to quit at any time.\n", color="cyan"
-    )
+    output("Type 'q' or use Ctrl-C to quit at any time.\n", "cyan")
     cprint("What can I do for you?", color="light_blue")
     need_user_request = True
     while True:

--- a/mentat/change_conflict_resolution.py
+++ b/mentat/change_conflict_resolution.py
@@ -1,15 +1,13 @@
 import logging
 import string
 
-from termcolor import cprint
-
 from .code_change import CodeChange, CodeChangeAction
 from .code_change_display import get_added_block, get_removed_block
-from .user_input_manager import UserInputManager
+from .interface import MentatInterface
 
 
 def resolve_insertion_conflicts(
-    changes: list[CodeChange], user_input_manager: UserInputManager, code_file_manager
+    changes: list[CodeChange], interface: MentatInterface, code_file_manager
 ) -> list[CodeChange]:
     """merges insertion conflicts into one singular code change"""
     insert_changes = list(
@@ -30,14 +28,14 @@ def resolve_insertion_conflicts(
             end += 1
         if end > cur + 1:
             logging.debug("insertion conflict")
-            cprint("Insertion conflict:", "red")
+            interface.display("Insertion conflict:", "red")
             for i in range(end - cur):
-                cprint(f"({string.printable[i]})", "green")
-                cprint("\n".join(insert_changes[cur + i].code_lines), "light_cyan")
-            cprint(
+                interface.display(f"({string.printable[i]})", "green")
+                interface.display("\n".join(insert_changes[cur + i].code_lines), "light_cyan")
+            interface.display(
                 "Type the order in which to insert changes (omit for no preference):"
             )
-            user_input = user_input_manager.collect_user_input()
+            user_input = interface.get_user_input()
             new_code_lines = []
             used = set()
             for c in user_input:
@@ -65,7 +63,7 @@ def resolve_insertion_conflicts(
 
 
 def resolve_non_insertion_conflicts(
-    changes: list[CodeChange], user_input_manager: UserInputManager
+    changes: list[CodeChange], interface: MentatInterface
 ) -> list[CodeChange]:
     """resolves delete-replace conflicts and asks user on delete-insert or replace-insert conflicts"""
     min_changed_line = changes[0].last_changed_line + 1
@@ -77,15 +75,15 @@ def resolve_non_insertion_conflicts(
                 if changes[i - 1].action == CodeChangeAction.Delete:
                     keep = True
                 else:
-                    cprint(
+                    interface.display(
                         "\nInsertion conflict: Lines inserted inside replaced block\n",
                         "light_red",
                     )
-                    print(get_removed_block(changes[i - 1]))
-                    print(get_added_block(change, prefix=">", color=None))
-                    print(get_added_block(changes[i - 1]))
-                    cprint("Keep this insertion?")
-                    keep = user_input_manager.ask_yes_no(default_yes=True)
+                    interface.display(get_removed_block(changes[i - 1]))
+                    interface.display(get_added_block(change, prefix=">", color=None))
+                    interface.display(get_added_block(changes[i - 1]))
+                    interface.display("Keep this insertion?")
+                    keep = interface.ask_yes_no(default_yes=True)
                 if keep:
                     change.first_changed_line = changes[i - 1].first_changed_line - 0.5
                     change.last_changed_line = change.first_changed_line

--- a/mentat/config_manager.py
+++ b/mentat/config_manager.py
@@ -4,7 +4,7 @@ from importlib import resources
 from json import JSONDecodeError
 from pathlib import Path
 
-from termcolor import cprint
+from .interface import MentatInterface
 
 mentat_dir_path = Path.home() / ".mentat"
 
@@ -19,12 +19,12 @@ old_config_file_path = mentat_dir_path / "config.json"
 
 
 class ConfigManager:
-    def __init__(self, git_root: str):
+    def __init__(self, git_root: str, interface: MentatInterface):
         git_root = Path(git_root)
 
         # Remove this warning after August 19
         if old_config_file_path.exists():
-            cprint(
+            interface.display(
                 "Warning: You are still using an old config.json in your ~/.mentat"
                 " directory. The config filename has recently been changed to"
                 " .mentat_config.json, and can be present in either ~/.mentat or the"
@@ -39,7 +39,7 @@ class ConfigManager:
                     self.user_config = json.load(config_file)
                 except JSONDecodeError:
                     logging.info("User config file contains invalid json")
-                    cprint(
+                    interface.display(
                         "Warning: User .mentat_config.json contains invalid"
                         " json; ignoring user configuration file",
                         "light_yellow",
@@ -55,7 +55,7 @@ class ConfigManager:
                     self.project_config = json.load(config_file)
                 except JSONDecodeError:
                     logging.info("Project config file contains invalid json")
-                    cprint(
+                    interface.display(
                         "Warning: Git project .mentat_config.json contains invalid"
                         " json; ignoring project configuration file",
                         "light_yellow",

--- a/mentat/conversation.py
+++ b/mentat/conversation.py
@@ -1,25 +1,27 @@
-from termcolor import cprint
-
 from .code_change import CodeChange
 from .code_file_manager import CodeFileManager
 from .config_manager import ConfigManager
 from .llm_api import CostTracker, check_model_availability, choose_model, count_tokens
 from .parsing import run_async_stream_and_parse_llm_response
 from .prompts import system_prompt
+from .interface import MentatInterface
 
 
 class Conversation:
     def __init__(
         self,
+        interface: MentatInterface,
         config: ConfigManager,
         cost_tracker: CostTracker,
         code_file_manager: CodeFileManager,
     ):
+        self.interface = interface
+        self.add_assistant_message
         self.messages = []
         self.add_system_message(system_prompt)
         self.cost_tracker = cost_tracker
         self.code_file_manager = code_file_manager
-        self.allow_32k = check_model_availability(config.allow_32k())
+        self.allow_32k = check_model_availability(self.interface, config.allow_32k())
 
         tokens = count_tokens(code_file_manager.get_code_message()) + count_tokens(
             system_prompt
@@ -31,13 +33,13 @@ class Conversation:
                 " Please try running again with a reduced number of files."
             )
         elif tokens + 1000 > token_limit:
-            cprint(
+            self.interface.display(
                 f"Warning: Included files are close to token limit ({tokens} /"
                 f" {token_limit}), you may not be able to have a long conversation.",
                 "red",
             )
         else:
-            cprint(f"File and prompt token count: {tokens} / {token_limit}", "cyan")
+            self.interface.display(f"File and prompt token count: {tokens} / {token_limit}", "cyan")
 
     def add_system_message(self, message: str):
         self.messages.append({"role": "system", "content": message})
@@ -54,13 +56,14 @@ class Conversation:
         code_message = self.code_file_manager.get_code_message()
         messages.append({"role": "system", "content": code_message})
 
-        model, num_prompt_tokens = choose_model(messages, self.allow_32k)
+        model, num_prompt_tokens = choose_model(self.interface, messages, self.allow_32k)
 
         state = run_async_stream_and_parse_llm_response(
-            messages, model, self.code_file_manager
+            self.interface, messages, model, self.code_file_manager
         )
 
         self.cost_tracker.display_api_call_stats(
+            self.interface,
             num_prompt_tokens,
             count_tokens(state.message),
             model,

--- a/mentat/interface.py
+++ b/mentat/interface.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from abc import ABC, abstractmethod
 from enum import Enum
 from typing import Callable, Dict, Iterable, Optional
@@ -7,10 +9,15 @@ from termcolor import cprint
 _interface_instance = None
 
 
-def get_interface() -> "MentatInterface":
+def get_interface() -> MentatInterface:
     if _interface_instance is None:
         raise Exception("Mentat interface not initialized")
     return _interface_instance
+
+
+# convenience function for common interaction
+def output(content: str, color: str):
+    get_interface().interact(content=content, color=color)
 
 
 class InterfaceType(Enum):

--- a/mentat/interface.py
+++ b/mentat/interface.py
@@ -1,0 +1,116 @@
+from abc import ABC, abstractmethod
+from enum import Enum
+from typing import Callable, Dict, Iterable, Optional
+
+from termcolor import cprint
+
+_interface_instance = None
+
+
+def get_interface() -> "MentatInterface":
+    if _interface_instance is None:
+        raise Exception("Mentat interface not initialized")
+    return _interface_instance
+
+
+class InterfaceType(Enum):
+    Terminal = "terminal"
+    VSCode = "vscode"
+
+
+def initialize_mentat_interface(
+    interface_type: InterfaceType,
+    interaction_callback: Optional[Callable[[Dict], str]] = None,
+):
+    global _interface_instance
+
+    # should only be initizalized once
+    assert _interface_instance is None
+
+    # callback provided iff interface_type is VSCode
+    assert (interface_type == InterfaceType.VSCode) == (
+        interaction_callback is not None
+    )
+
+    match interface_type:
+        case InterfaceType.Terminal:
+            _interface_instance = TerminalMentatInterface()
+        case InterfaceType.VSCode:
+            _interface_instance = VSCodeMentatInterface(interaction_callback)
+
+
+class MentatInterface(ABC):
+    @abstractmethod
+    def interact(
+        self,
+        content: Optional[str] = None,
+        color: Optional[str] = None,
+        is_error: Optional[bool] = False,
+        return_user_input: Optional[bool] = False,
+        user_input_options: Optional[Iterable[str]] = None,
+    ) -> str:
+        """Handle both receiving input and sending output using the provided callback."""
+        pass
+
+    @abstractmethod
+    def interrupt(self):
+        """Handle user interruptions."""
+        pass
+
+    @abstractmethod
+    def exit(self):
+        """Handle cleanup or exit procedures."""
+        pass
+
+
+class TerminalMentatInterface(MentatInterface):
+    def interact(
+        self,
+        content: Optional[str] = None,
+        color: Optional[str] = None,
+        is_error: Optional[bool] = False,
+        return_user_input: Optional[bool] = False,
+        user_input_options: Optional[Iterable[str]] = None,
+    ) -> str:
+        if content:
+            if color:
+                cprint(content, color=color)
+            else:
+                print(content)
+        if return_user_input:
+            # get and return user input
+            pass
+
+    def interrupt(self):
+        pass
+
+    def exit(self):
+        pass
+
+
+class VSCodeMentatInterface(MentatInterface):
+    def __init__(self, interaction_callback: Callable):
+        self.interaction_callback = interaction_callback
+
+    def interact(
+        self,
+        content: Optional[str] = None,
+        color: Optional[str] = None,
+        is_error: Optional[bool] = False,
+        return_user_input: Optional[bool] = False,
+        user_input_options: Optional[Iterable[str]] = None,
+    ) -> str:
+        """Handle both receiving input and sending output using the provided callback."""
+        return self.interaction_callback(
+            content=content,
+            color=color,
+            is_error=is_error,
+            return_user_input=return_user_input,
+            user_input_options=user_input_options,
+        )
+
+    def interrupt(self):
+        pass
+
+    def exit(self):
+        pass

--- a/mentat/streaming_printer.py
+++ b/mentat/streaming_printer.py
@@ -1,11 +1,10 @@
 import asyncio
 from collections import deque
 
-from termcolor import colored
-
 
 class StreamingPrinter:
-    def __init__(self):
+    def __init__(self, interface):
+        self.interface = interface
         self.strings_to_print = deque([])
         self.chars_remaining = 0
         self.shutdown = False
@@ -14,14 +13,7 @@ class StreamingPrinter:
         if len(string) == 0:
             return
         string += end
-
-        colored_string = colored(string, color) if color is not None else string
-
-        index = colored_string.index(string)
         characters = list(string)
-        characters[0] = colored_string[:index] + characters[0]
-        characters[-1] = characters[-1] + colored_string[index + len(string) :]
-
         self.strings_to_print.extend(characters)
         self.chars_remaining += len(characters)
 
@@ -36,7 +28,7 @@ class StreamingPrinter:
         while True:
             if self.strings_to_print:
                 next_string = self.strings_to_print.popleft()
-                print(next_string, end="", flush=True)
+                self.interface.display(next_string, end="")
                 self.chars_remaining -= 1
             elif self.shutdown:
                 break

--- a/mentat/user_input_manager.py
+++ b/mentat/user_input_manager.py
@@ -7,7 +7,6 @@ from prompt_toolkit.filters import Condition
 from prompt_toolkit.history import FileHistory
 from prompt_toolkit.key_binding import KeyBindings
 from prompt_toolkit.styles import Style
-from termcolor import cprint
 
 from .config_manager import ConfigManager, mentat_dir_path
 
@@ -73,20 +72,3 @@ class UserInputManager:
         return (
             "" if is_soft_wrap else [("class:continuation", " " * (width - 2) + "> ")]
         )
-
-    def collect_user_input(self) -> str:
-        user_input = self.session.prompt().strip()
-        logging.debug(f"User input:\n{user_input}")
-        if user_input.lower() == "q":
-            raise UserQuitInterrupt()
-        return user_input
-
-    def ask_yes_no(self, default_yes: bool) -> bool:
-        cprint("(Y/n)" if default_yes else "(y/N)")
-        while (user_input := self.collect_user_input().lower()) not in [
-            "y",
-            "n",
-            "",
-        ]:
-            cprint("(Y/n)" if default_yes else "(y/N)")
-        return user_input == "y" or (user_input != "n" and default_yes)

--- a/mentat_runner_concept.py
+++ b/mentat_runner_concept.py
@@ -1,0 +1,161 @@
+import asyncio
+
+# --------------------------
+# UI Interface (e.g. terminal, vscode)
+# --------------------------
+class MentatInterface:
+    def __init__(self):
+        pass
+
+    def register_runner(self, runner):
+        self.runner = runner
+
+class TerminalMentatInterface(MentatInterface):
+    """Used to communicate with the terminal"""
+    _is_streaming = False
+    def print(self, content, color=None, stream=False):
+        """Render output to the UI"""
+        if stream:
+            kwargs = {'end': '', 'flush': True}
+            self._is_streaming = True
+        else:
+            kwargs = {}
+            if self._is_streaming:
+                self._is_streaming = False
+                self.print('')
+        print(content, **kwargs)
+
+    # This is the 'infinite loop' used to get user input from terminal.
+    # VSCode won't need a loop; it will proactively call get_response via 
+    # a LanguageServer command.
+    async def start(self):
+        while True:
+            user_input = await asyncio.get_event_loop().run_in_executor(None, input)
+            await self.runner.get_response(user_input)
+
+class VSCodeInterface(MentatInterface):
+    def __init__(self, print_handler):
+        self.print_handler = print_handler
+
+    def print(self, content, *args, **kwargs):
+        self.print_handler(content, *args, **kwargs)
+        
+
+# --------------------------
+# Mentat Instance
+# --------------------------
+DEFAULT_SLEEP_TIME = 0.1
+class MentatRunner:
+    def __init__(self, interface):
+        self.interface = interface
+        self.interface.register_runner(self)
+        self.print('Welcome to Mentat!\nWhat can I do for you?')
+    
+    # --------------------
+    # Handle User Input
+    # --------------------
+    _conversation = []  # Stand-in for Conversation
+    _prompt_options = None
+    _user_prompt_option = None
+    async def get_response(self, prompt):
+        if self._prompt_options is not None:
+            _prompt = prompt.lower()
+            if _prompt not in self._prompt_options:
+                echo = self._conversation[-1]
+                self.print('Invalid response')
+                self.print(echo)
+            else:
+                self._conversation.append(_prompt)
+                self._user_prompt_option = _prompt
+        else:
+            # Run async commands in the background
+            self._conversation.append(prompt)
+            asyncio.create_task(get_llm_response(self, prompt))
+
+    _is_streaming = False
+    _interrupt_callback = None
+    def interrupt(self):
+        self.print('Interrupting')
+        if self._interrupt_callback is not None:
+            self._interrupt_callback()
+        self._is_streaming = False  # Intercepted by stream_manager
+            
+    # --------------------
+    # Methods to be used by Mentat funcs
+    # --------------------
+    _was_streaming = False
+    def print(self, content, *args, **kwargs):
+        if self._was_streaming and self._is_streaming:
+            self._conversation[-1] += content
+        else:
+            self._conversation.append(content)
+            self._was_streaming = self._is_streaming == True
+        self.interface.print(content, *args, **kwargs)
+
+    async def ask_yes_no(self, content, *args, **kwargs):
+        self.print(f'{content} (y/n)', *args, **kwargs)
+        self._prompt_options = {'y', 'n'}
+        async def response_watcher():
+            while True:
+                if self._user_prompt_option is not None:
+                    response = self._user_prompt_option
+                    self._prompt_options = None
+                    self._user_prompt_option = None
+                    return response == 'y'
+                await asyncio.sleep(DEFAULT_SLEEP_TIME)
+        return await asyncio.create_task(response_watcher())
+    
+    async def initialize_stream(self, interrupt_callback=False):
+        self._is_streaming = True
+        self._stream_buffer = ''
+        self._interrupt_callback = interrupt_callback
+        
+        # Loop to transfer stream buffer to interface
+        async def stream_manager():
+            while self._is_streaming:
+                if (self._stream_buffer):
+                    self.print(self._stream_buffer, stream=True)
+                self._stream_buffer = ''
+                await asyncio.sleep(DEFAULT_SLEEP_TIME)
+            self._stream_buffer = ''
+            self._interrupt_callback = None
+        asyncio.create_task(stream_manager())
+        
+        # Send a stream_handler and done callback to the task
+        async def stream_handler(content): 
+            self._stream_buffer += content
+        async def done(): 
+            self._is_streaming = False
+        return stream_handler, done
+    
+# --------------------------
+# External Methods (e.g.)
+# --------------------------
+async def get_llm_response(
+        runner: MentatRunner, 
+        prompt: str,
+):
+    
+    # Stream a response:
+    def interrupt_callback():
+        runner.print('Terminating Async Process')  # e.g. The openai stream
+    stream_handler, done = await runner.initialize_stream(interrupt_callback)
+    message = f'Ok, I\'ll {prompt}.'
+    for char in message:
+        await stream_handler(char)
+        await asyncio.sleep(0.05)
+    await done()
+
+    # Get yes/no confirmation
+    if await runner.ask_yes_no('Apply these changes?'):
+        runner.print('Applying changes')
+    else:
+        runner.print('Not applying changes')
+    runner.print('What else can I do for you?')
+
+# --------------------------
+# Run the TerminalInterface Loop
+# --------------------------
+interface = TerminalMentatInterface()
+MR = MentatRunner(interface)
+asyncio.run(MR.interface.start())

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ with open(readme_path, "r", encoding="utf-8") as f:
 
 setup(
     name="mentat-ai",
-    version="0.1.10",
+    version="0.1.11",
     python_requires=">=3.10",
     packages=find_packages(),
     install_requires=read_requirements("requirements.txt"),


### PR DESCRIPTION
For #63 , a perquisite to merge #70 

Right now it's just a sketch of how this could work. Before merging we'd finalize design and replace all calls to `print` and `cprint` in the codebase, figure out error handling, and call user input messages from the new interface.

@waydegg @granawkins @PCSwingle let me know what you think, I'll continue to work on this tomorrow

The main idea is that we'll run output through the `interact` function - mostly it'll be output from Mentat to be displayed on the terminal or editor extension, but sometimes interact will be called with `return_user_input=True`, meaning the user should respond. Available user options (yes, no, etc) can be provided through `user_input_options`. I imagine in the future we'll sometimes send things to `interact` that aren't just text information, but raw data (costs, etc), and it'd be up to the interface how to display that.

Feel free to suggest better naming for anything as well