### PR TITLE
turn all singletons into context vars, remove git_root from config

### DIFF
--- a/mentat/code_context.py
+++ b/mentat/code_context.py
@@ -215,7 +215,7 @@ class CodeContext:
         await stream.send(git_root.name, color="blue")
         await _print_path_tree(
             _build_path_tree(list(self.files.values()), git_root),
-            get_paths_with_git_diffs(git_root),
+            get_paths_with_git_diffs(),
             git_root,
         )
         await self.diff_context.display_context()

--- a/mentat/code_context.py
+++ b/mentat/code_context.py
@@ -3,25 +3,21 @@ from __future__ import annotations
 import glob
 import logging
 import os
+from contextvars import ContextVar
 from pathlib import Path
 from textwrap import dedent
-from typing import TYPE_CHECKING, Any, Dict, Optional
+from typing import Any, Dict, Optional
 
 import attr
 
 from .code_file import CodeFile
 from .code_map import CodeMap
-from .config_manager import ConfigManager
-from .diff_context import get_diff_context
+from .config_manager import CONFIG_MANAGER, ConfigManager
+from .diff_context import DiffContext
 from .errors import MentatError, UserError
-from .git_handler import get_non_gitignored_files, get_paths_with_git_diffs
+from .git_handler import GIT_ROOT, get_non_gitignored_files, get_paths_with_git_diffs
 from .llm_api import count_tokens, model_context_size
 from .session_stream import SESSION_STREAM
-
-if TYPE_CHECKING:
-    # This normally will cause a circular import
-    from mentat.code_file_manager import CodeFileManager
-    from mentat.parsers.parser import Parser
 
 
 def _is_file_text_encoded(file_path: Path):
@@ -67,7 +63,7 @@ def _abs_files_from_list(paths: list[Path], check_for_text: bool = True):
 
 
 def _get_files(
-    config: ConfigManager, paths: list[Path], exclude_paths: list[Path]
+    config: ConfigManager, git_root: Path, paths: list[Path], exclude_paths: list[Path]
 ) -> Dict[Path, CodeFile]:
     excluded_files_direct, excluded_files_from_dirs = _abs_files_from_list(
         exclude_paths, check_for_text=False
@@ -77,12 +73,12 @@ def _get_files(
     ), set(map(lambda f: f.path, excluded_files_from_dirs))
 
     glob_excluded_files = set(
-        os.path.join(config.git_root, file)
+        os.path.join(git_root, file)
         for glob_path in config.file_exclude_glob_list()
         # If the user puts a / at the beginning, it will try to look in root directory
         for file in glob.glob(
             pathname=glob_path,
-            root_dir=config.git_root,
+            root_dir=git_root,
             recursive=True,
         )
     )
@@ -156,44 +152,33 @@ class CodeContextSettings:
         return attr.asdict(self)
 
 
+CODE_CONTEXT: ContextVar[CodeContext] = ContextVar("mentat:code_context")
+
+
 class CodeContext:
     settings: CodeContextSettings
     files: dict[Path, CodeFile]  # included path -> CodeFile
     file_lines: dict[Path, list[str]]  # included path -> cached lines
 
-    def __init__(self, config: ConfigManager, settings: CodeContextSettings):
-        self.config = config
+    def __init__(self, settings: CodeContextSettings):
         self.settings = settings
 
     @classmethod
-    async def create(
-        cls,
-        config: ConfigManager,
-        paths: list[Path],
-        exclude_paths: list[Path],
-        diff: Optional[str] = None,
-        pr_diff: Optional[str] = None,
-        no_code_map: bool = False,
-    ):
-        settings = CodeContextSettings(
-            paths=paths,
-            exclude_paths=exclude_paths,
-            diff=diff,
-            pr_diff=pr_diff,
-            no_code_map=no_code_map,
-        )
-        self = CodeContext(config, settings)
+    async def create(cls, settings: CodeContextSettings):
+        self = cls(settings)
         await self.refresh(replace_paths=True)
 
         return self
 
-    async def refresh(self, replace_paths: bool | None = False):
+    async def refresh(self, replace_paths: bool = False):
         stream = SESSION_STREAM.get()
+        config = CONFIG_MANAGER.get()
+        git_root = GIT_ROOT.get()
 
         # Diff context
         try:
-            self.diff_context = get_diff_context(
-                self.config, self.settings.diff, self.settings.pr_diff
+            self.diff_context = DiffContext.create(
+                self.settings.diff, self.settings.pr_diff
             )
             if replace_paths and not self.settings.paths:
                 self.settings.paths = self.diff_context.files
@@ -202,11 +187,11 @@ class CodeContext:
             raise MentatError("Failed to create diff context.")
         # User-specified Files
         self.files = _get_files(
-            self.config, self.settings.paths, self.settings.exclude_paths
+            config, git_root, self.settings.paths, self.settings.exclude_paths
         )
         # Universal ctags
         self.code_map = (
-            await CodeMap.create(self.config, token_limit=2048)
+            await CodeMap.create(token_limit=2048)
             if not self.settings.no_code_map
             else None
         )
@@ -220,24 +205,29 @@ class CodeContext:
 
     async def display_context(self):
         stream = SESSION_STREAM.get()
+        git_root = GIT_ROOT.get()
 
         if self.files:
             await stream.send("Files included in context:", color="green")
         else:
             await stream.send("No files included in context.\n", color="red")
             await stream.send("Git project: ", color="green", end="")
-        await stream.send(self.config.git_root.name, color="blue")
+        await stream.send(git_root.name, color="blue")
         await _print_path_tree(
-            _build_path_tree(list(self.files.values()), self.config.git_root),
-            get_paths_with_git_diffs(self.config.git_root),
-            self.config.git_root,
+            _build_path_tree(list(self.files.values()), git_root),
+            get_paths_with_git_diffs(git_root),
+            git_root,
         )
         await self.diff_context.display_context()
 
     async def get_code_message(
-        self, model: str, code_file_manager: CodeFileManager, parser: Parser
+        self,
+        all_file_lines: dict[Path, list[str]],
+        model: str,
+        provide_line_numbers: bool,
     ) -> str:
         stream = SESSION_STREAM.get()
+        git_root = GIT_ROOT.get()
 
         code_message: list[str] = []
         if self.diff_context.files:
@@ -248,21 +238,20 @@ class CodeContext:
                 "",
             ]
 
-        code_file_manager.read_all_file_lines(list(self.files.keys()))
         code_message += ["Code Files:\n"]
         for file in self.files.values():
             file_message: list[str] = []
             abs_path = file.path
-            rel_path = Path(os.path.relpath(abs_path, self.config.git_root))
+            rel_path = Path(os.path.relpath(abs_path, git_root))
 
             # We always want to give GPT posix paths
             posix_rel_path = Path(rel_path).as_posix()
             file_message.append(posix_rel_path)
 
-            file_lines = code_file_manager.file_lines[rel_path]
+            file_lines = all_file_lines[rel_path]
             for i, line in enumerate(file_lines, start=1):
                 if file.contains_line(i):
-                    if parser.provide_line_numbers():
+                    if provide_line_numbers:
                         file_message.append(f"{i}:{line}")
                     else:
                         file_message.append(f"{line}")

--- a/mentat/code_edit_feedback.py
+++ b/mentat/code_edit_feedback.py
@@ -2,20 +2,16 @@ from mentat.parsers.file_edit import FileEdit
 from mentat.session_input import collect_user_input
 from mentat.session_stream import SESSION_STREAM
 
-from .code_context import CodeContext
-from .code_file_manager import CodeFileManager
-from .config_manager import ConfigManager
-from .conversation import Conversation
+from .code_file_manager import CODE_FILE_MANAGER
+from .conversation import CONVERSATION
 
 
 async def get_user_feedback_on_edits(
-    config: ConfigManager,
-    conv: Conversation,
-    code_file_manager: CodeFileManager,
-    code_context: CodeContext,
     file_edits: list[FileEdit],
 ) -> bool:
     stream = SESSION_STREAM.get()
+    conversation = CONVERSATION.get()
+    code_file_manager = CODE_FILE_MANAGER.get()
 
     await stream.send(
         "Apply these changes? 'Y/n/i' or provide feedback.",
@@ -28,15 +24,15 @@ async def get_user_feedback_on_edits(
     match user_response.lower():
         case "y" | "":
             edits_to_apply = file_edits
-            conv.add_user_message("User chose to apply all your changes.")
+            conversation.add_user_message("User chose to apply all your changes.")
         case "n":
             edits_to_apply = []
-            conv.add_user_message("User chose not to apply any of your changes.")
-        case "i":
-            edits_to_apply = await user_filter_changes(
-                code_file_manager, config, file_edits
+            conversation.add_user_message(
+                "User chose not to apply any of your changes."
             )
-            conv.add_user_message(
+        case "i":
+            edits_to_apply = await _user_filter_changes(file_edits)
+            conversation.add_user_message(
                 "User chose to apply"
                 f" {len(edits_to_apply)}/{len(file_edits)} of your suggested"
                 " changes."
@@ -44,7 +40,7 @@ async def get_user_feedback_on_edits(
         case _:
             need_user_request = False
             edits_to_apply = []
-            conv.add_user_message(
+            conversation.add_user_message(
                 "User chose not to apply any of your changes. User response:"
                 f" {user_response}\n\nPlease adjust your previous plan and changes to"
                 " reflect this. Respond with a full new set of changes."
@@ -54,9 +50,7 @@ async def get_user_feedback_on_edits(
         await file_edit.resolve_conflicts()
 
     if edits_to_apply:
-        await code_file_manager.write_changes_to_files(
-            file_edits=edits_to_apply, code_context=code_context
-        )
+        await code_file_manager.write_changes_to_files(file_edits=edits_to_apply)
         await stream.send("Changes applied.", color="light_blue")
     else:
         await stream.send("No changes applied.", color="light_blue")
@@ -67,14 +61,10 @@ async def get_user_feedback_on_edits(
     return need_user_request
 
 
-async def user_filter_changes(
-    code_file_manager: CodeFileManager,
-    config: ConfigManager,
-    file_edits: list[FileEdit],
-) -> list[FileEdit]:
+async def _user_filter_changes(file_edits: list[FileEdit]) -> list[FileEdit]:
     new_edits = list[FileEdit]()
     for file_edit in file_edits:
-        if await file_edit.filter_replacements(code_file_manager, config):
+        if await file_edit.filter_replacements():
             new_edits.append(file_edit)
 
     return new_edits

--- a/mentat/code_map.py
+++ b/mentat/code_map.py
@@ -7,8 +7,8 @@ from pathlib import Path
 from textwrap import dedent
 from typing import Any, Literal
 
-from .config_manager import ConfigManager
-from .git_handler import get_non_gitignored_files
+from .config_manager import CONFIG_MANAGER, ConfigManager
+from .git_handler import GIT_ROOT, get_non_gitignored_files
 from .llm_api import count_tokens
 from .session_stream import SESSION_STREAM
 
@@ -131,17 +131,16 @@ class CodeMapMessage:
 
 
 class CodeMap:
-    def __init__(self, config: ConfigManager, token_limit: int | None = None):
-        self.config = config
-        self.git_root = self.config.git_root
+    def __init__(self, token_limit: int | None = None):
         self.token_limit = token_limit
-
         self.ctags_disabled = True
         self.ctags_disabled_reason = ""
 
     @classmethod
-    async def create(cls, config: ConfigManager, token_limit: int | None = None):
-        self = cls(config, token_limit)
+    async def create(cls, token_limit: int | None = None):
+        stream = SESSION_STREAM.get()
+
+        self = cls(token_limit)
         await self._check_ctags_executable()
         if self.ctags_disabled:
             ctags_disabled_message = f"""
@@ -149,7 +148,7 @@ class CodeMap:
                 Reason: {self.ctags_disabled_reason}
             """
             ctags_disabled_message = dedent(ctags_disabled_message)
-            await SESSION_STREAM.get().send(ctags_disabled_message, color="yellow")
+            await stream.send(ctags_disabled_message, color="yellow")
 
         return self
 
@@ -187,26 +186,30 @@ class CodeMap:
 
     async def _get_message_from_ctags(
         self,
+        config: ConfigManager,
         root: Path,
         file_paths: set[Path],
         exclude_signatures: bool = False,
         token_limit: int | None = None,
     ) -> CodeMapMessage | None:
         token_limit = token_limit or self.token_limit
-
         code_maps = list[str]()
         code_maps_token_count = 0
         for file_path in file_paths:
             code_map = await _get_code_map(
                 root, file_path, exclude_signatures=exclude_signatures
             )
-            code_map_token_count = count_tokens(code_map, self.config.model())
+            code_map_token_count = count_tokens(code_map, config.model())
 
             if token_limit is not None and code_maps_token_count > token_limit:
                 if exclude_signatures is True:
                     return
                 return await self._get_message_from_ctags(
-                    root, file_paths, exclude_signatures=True, token_limit=token_limit
+                    config,
+                    root,
+                    file_paths,
+                    exclude_signatures=True,
+                    token_limit=token_limit,
                 )
 
             code_maps.append(code_map)
@@ -214,12 +217,12 @@ class CodeMap:
 
         message = "Code Map:" + "\n\n" + "\n".join(code_maps)
 
-        message_token_count = count_tokens(message, self.config.model())
+        message_token_count = count_tokens(message, config.model())
         if token_limit is not None and message_token_count > token_limit:
             if exclude_signatures is True:
                 return
             return await self._get_message_from_ctags(
-                root, file_paths, exclude_signatures=True
+                config, root, file_paths, exclude_signatures=True
             )
 
         code_map_message = CodeMapMessage(
@@ -230,13 +233,15 @@ class CodeMap:
         return code_map_message
 
     def _get_message_from_file_map(
-        self, file_paths: set[Path], token_limit: int | None = None
+        self,
+        config: ConfigManager,
+        file_paths: set[Path],
+        token_limit: int | None = None,
     ) -> CodeMapMessage | None:
         file_map_tree = _get_file_map(file_paths)
-
         message = "Code Map:" + "\n\n" + file_map_tree
 
-        message_token_count = count_tokens(message, self.config.model())
+        message_token_count = count_tokens(message, config.model())
         token_limit = token_limit or self.token_limit
         if token_limit is not None and message_token_count > token_limit:
             return
@@ -248,17 +253,20 @@ class CodeMap:
     async def get_message(
         self, token_limit: int | None = None
     ) -> CodeMapMessage | None:
-        git_file_paths = get_non_gitignored_files(self.git_root)
+        config = CONFIG_MANAGER.get()
+        git_root = GIT_ROOT.get()
+
+        git_file_paths = get_non_gitignored_files(git_root)
 
         if not self.ctags_disabled:
             code_map_message = await self._get_message_from_ctags(
-                self.git_root, git_file_paths, token_limit=token_limit
+                config, git_root, git_file_paths, token_limit=token_limit
             )
             if code_map_message is not None:
                 return code_map_message
 
         file_map_message = self._get_message_from_file_map(
-            git_file_paths, token_limit=token_limit
+            config, git_file_paths, token_limit=token_limit
         )
         if file_map_message is not None:
             return file_map_message

--- a/mentat/commands.py
+++ b/mentat/commands.py
@@ -1,11 +1,11 @@
 from __future__ import annotations
 
 from abc import ABC, abstractmethod
-from typing import List, Optional
+from typing import List
 
 from mentat.session_stream import SESSION_STREAM
 
-from .code_context import CodeContext
+from .code_context import CODE_CONTEXT
 from .code_file import CodeFile
 from .errors import MentatError
 from .git_handler import commit
@@ -20,21 +20,12 @@ class Command(ABC):
             Command._registered_commands[command_name] = cls
 
     @classmethod
-    def create_command(
-        cls, command_name: str, code_context: Optional[CodeContext] = None
-    ) -> Command:
+    def create_command(cls, command_name: str) -> Command:
         if command_name not in cls._registered_commands:
             return InvalidCommand(command_name)
 
         command_cls = cls._registered_commands[command_name]
-        if command_cls in [AddCommand, RemoveCommand]:
-            if code_context is None:
-                raise MentatError(
-                    f"Code context must be provided for {command_cls.__name__}"
-                )
-            return command_cls(code_context)
-        else:
-            return command_cls()
+        return command_cls()
 
     @classmethod
     def get_command_completions(cls) -> List[str]:
@@ -132,18 +123,16 @@ class CommitCommand(Command, command_name="commit"):
 
 
 class AddCommand(Command, command_name="add"):
-    def __init__(self, code_context: CodeContext):
-        self.code_context = code_context
-
     async def apply(self, *args: str) -> None:
         stream = SESSION_STREAM.get()
+        code_context = CODE_CONTEXT.get()
 
         if len(args) == 0:
             await stream.send("No files specified\n", color="yellow")
             return
         for file_path in args:
             code_file = CodeFile(file_path)
-            await self.code_context.add_file(code_file)
+            await code_context.add_file(code_file)
 
     @classmethod
     def argument_names(cls) -> list[str]:
@@ -155,17 +144,16 @@ class AddCommand(Command, command_name="add"):
 
 
 class RemoveCommand(Command, command_name="remove"):
-    def __init__(self, code_context: CodeContext):
-        self.code_context = code_context
-
     async def apply(self, *args: str) -> None:
         stream = SESSION_STREAM.get()
+        code_context = CODE_CONTEXT.get()
+
         if len(args) == 0:
             await stream.send("No files specified\n", color="yellow")
             return
         for file_path in args:
             code_file = CodeFile(file_path)
-            await self.code_context.remove_file(code_file)
+            await code_context.remove_file(code_file)
 
     @classmethod
     def argument_names(cls) -> list[str]:

--- a/mentat/conversation.py
+++ b/mentat/conversation.py
@@ -30,8 +30,13 @@ CONVERSATION: ContextVar[Conversation] = ContextVar("mentat:conversation")
 class Conversation:
     def __init__(self):
         config = CONFIG_MANAGER.get()
+        parser = PARSER.get()
+
         self.model = config.model()
         self.messages = list[dict[str, str]]()
+
+        prompt = parser.get_system_prompt()
+        self.add_system_message(prompt)
 
     async def display_token_count(self):
         stream = SESSION_STREAM.get()
@@ -60,8 +65,6 @@ class Conversation:
                 )
 
         prompt = parser.get_system_prompt()
-        self.add_system_message(prompt)
-
         code_file_manager.read_all_file_lines()
         tokens = count_tokens(
             await code_context.get_code_message(

--- a/mentat/conversation.py
+++ b/mentat/conversation.py
@@ -1,16 +1,19 @@
+from __future__ import annotations
+
+from contextvars import ContextVar
 from timeit import default_timer
 
 from openai.error import InvalidRequestError, RateLimitError
 
 from mentat.parsers.file_edit import FileEdit
-from mentat.parsers.parser import Parser
+from mentat.parsers.parser import PARSER, Parser
+from tests.conftest import CODE_FILE_MANAGER, SessionStream
 
-from .code_context import CodeContext
-from .code_file_manager import CodeFileManager
-from .config_manager import ConfigManager, user_config_path
+from .code_context import CODE_CONTEXT
+from .config_manager import CONFIG_MANAGER, user_config_path
 from .errors import MentatError, UserError
 from .llm_api import (
-    CostTracker,
+    COST_TRACKER,
     call_llm_api,
     count_tokens,
     get_prompt_token_count,
@@ -19,34 +22,21 @@ from .llm_api import (
 )
 from .session_stream import SESSION_STREAM
 
+CONVERSATION: ContextVar[Conversation] = ContextVar("mentat:conversation")
+
 
 class Conversation:
-    def __init__(
-        self,
-        config: ConfigManager,
-        cost_tracker: CostTracker,
-        code_context: CodeContext,
-        code_file_manager: CodeFileManager,
-    ):
-        self.cost_tracker = cost_tracker
-        self.code_context = code_context
-        self.code_file_manager = code_file_manager
+    def __init__(self):
+        config = CONFIG_MANAGER.get()
         self.model = config.model()
-
         self.messages = list[dict[str, str]]()
 
-    @classmethod
-    async def create(
-        cls,
-        parser: Parser,
-        config: ConfigManager,
-        cost_tracker: CostTracker,
-        code_context: CodeContext,
-        code_file_manager: CodeFileManager,
-    ):
+    async def display_token_count(self):
         stream = SESSION_STREAM.get()
-
-        self = Conversation(config, cost_tracker, code_context, code_file_manager)
+        parser = PARSER.get()
+        code_context = CODE_CONTEXT.get()
+        config = CONFIG_MANAGER.get()
+        code_file_manager = CODE_FILE_MANAGER.get()
 
         if not is_model_available(self.model):
             raise MentatError(
@@ -70,9 +60,10 @@ class Conversation:
         prompt = parser.get_system_prompt()
         self.add_system_message(prompt)
 
+        code_file_manager.read_all_file_lines()
         tokens = count_tokens(
             await code_context.get_code_message(
-                self.model, self.code_file_manager, parser
+                code_file_manager.file_lines, self.model, parser.provide_line_numbers()
             ),
             self.model,
         ) + count_tokens(prompt, self.model)
@@ -108,8 +99,6 @@ class Conversation:
                 color="cyan",
             )
 
-        return self
-
     def add_system_message(self, message: str):
         self.messages.append({"role": "system", "content": message})
 
@@ -121,12 +110,10 @@ class Conversation:
 
     async def _stream_model_response(
         self,
+        stream: SessionStream,
         parser: Parser,
-        config: ConfigManager,
         messages: list[dict[str, str]],
     ):
-        stream = SESSION_STREAM.get()
-
         start_time = default_timer()
         try:
             response = await call_llm_api(messages, self.model)
@@ -135,7 +122,7 @@ class Conversation:
             )
             async with parser.interrupt_catcher():
                 message, file_edits = await parser.stream_and_parse_llm_response(
-                    response, self.code_file_manager, config
+                    response
                 )
         except InvalidRequestError as e:
             raise MentatError(
@@ -149,20 +136,26 @@ class Conversation:
         time_elapsed = default_timer() - start_time
         return (message, file_edits, time_elapsed)
 
-    async def get_model_response(
-        self, parser: Parser, config: ConfigManager
-    ) -> list[FileEdit]:
+    async def get_model_response(self) -> list[FileEdit]:
+        stream = SESSION_STREAM.get()
+        code_context = CODE_CONTEXT.get()
+        cost_tracker = COST_TRACKER.get()
+        code_file_manager = CODE_FILE_MANAGER.get()
+        parser = PARSER.get()
+
         messages = self.messages.copy()
-        code_message = await self.code_context.get_code_message(
-            self.model, self.code_file_manager, parser
+
+        code_file_manager.read_all_file_lines()
+        code_message = await code_context.get_code_message(
+            code_file_manager.file_lines, self.model, parser.provide_line_numbers()
         )
         messages.append({"role": "system", "content": code_message})
 
         num_prompt_tokens = await get_prompt_token_count(messages, self.model)
         message, file_edits, time_elapsed = await self._stream_model_response(
-            parser, config, messages
+            stream, parser, messages
         )
-        await self.cost_tracker.display_api_call_stats(
+        await cost_tracker.display_api_call_stats(
             num_prompt_tokens,
             count_tokens(message, self.model),
             self.model,

--- a/mentat/diff_context.py
+++ b/mentat/diff_context.py
@@ -129,21 +129,18 @@ class DiffContext:
                     f"Cannot identify merge base between HEAD and {pr_diff}"
                 )
 
-        meta = get_treeish_metadata(git_root, target)
+        meta = get_treeish_metadata(target)
         name += f'{meta["hexsha"][:8]}: {meta["summary"]}'
         return cls(target, name)
 
     @property
     def files(self) -> list[Path]:
-        git_root = GIT_ROOT.get()
-
-        if self.target == "HEAD" and not check_head_exists(git_root):
+        if self.target == "HEAD" and not check_head_exists():
             return []  # A new repo without any commits
-        return get_files_in_diff(git_root, self.target)
+        return get_files_in_diff(self.target)
 
     async def display_context(self) -> None:
         stream = SESSION_STREAM.get()
-        git_root = GIT_ROOT.get()
 
         if not self.files:
             return
@@ -152,7 +149,7 @@ class DiffContext:
         num_lines = 0
         # TODO: Only include paths in context
         for file in self.files:
-            diff = get_diff_for_file(git_root, self.target, file)
+            diff = get_diff_for_file(self.target, file)
             diff_lines = diff.splitlines()
             num_lines += len(
                 [line for line in diff_lines if line.startswith(("+ ", "- "))]
@@ -164,11 +161,9 @@ class DiffContext:
     ) -> list[str]:
         """Return file_message annotated with active diff."""
 
-        git_root = GIT_ROOT.get()
-
         if not self.files:
             return file_message
-        diff = get_diff_for_file(git_root, self.target, rel_path)
+        diff = get_diff_for_file(self.target, rel_path)
         annotations = _parse_diff(diff)
         return _annotate_file_message(file_message, annotations)
 

--- a/mentat/git_handler.py
+++ b/mentat/git_handler.py
@@ -9,7 +9,8 @@ from mentat.errors import UserError
 GIT_ROOT: ContextVar[Path] = ContextVar("mentat:git_root")
 
 
-def get_git_diff_for_path(git_root: Path, path: Path) -> str:
+def get_git_diff_for_path(path: Path) -> str:
+    git_root = GIT_ROOT.get()
     return subprocess.check_output(["git", "diff", path], cwd=git_root).decode("utf-8")
 
 
@@ -30,7 +31,9 @@ def get_non_gitignored_files(path: Path) -> set[Path]:
     )
 
 
-def get_paths_with_git_diffs(git_root: Path) -> set[Path]:
+def get_paths_with_git_diffs() -> set[Path]:
+    git_root = GIT_ROOT.get()
+
     changed = subprocess.check_output(
         ["git", "diff", "--name-only"], cwd=git_root, text=True
     ).split("\n")
@@ -106,8 +109,10 @@ def commit(message: str) -> None:
     subprocess.run(["git", "commit", "-m", message])
 
 
-def get_diff_for_file(git_root: Path, target: str, path: Path) -> str:
+def get_diff_for_file(target: str, path: Path) -> str:
     """Return commit data & diff for target versus active code"""
+    git_root = GIT_ROOT.get()
+
     try:
         diff_content = subprocess.check_output(
             ["git", "diff", "-U0", f"{target}", "--", path], cwd=git_root, text=True
@@ -118,7 +123,9 @@ def get_diff_for_file(git_root: Path, target: str, path: Path) -> str:
         raise UserError()
 
 
-def get_treeish_metadata(git_root: Path, target: str) -> dict[str, str]:
+def get_treeish_metadata(target: str) -> dict[str, str]:
+    git_root = GIT_ROOT.get()
+
     try:
         commit_info = subprocess.check_output(
             ["git", "log", target, "-n", "1", "--pretty=format:%H %s"],
@@ -134,8 +141,10 @@ def get_treeish_metadata(git_root: Path, target: str) -> dict[str, str]:
         raise UserError()
 
 
-def get_files_in_diff(git_root: Path, target: str) -> list[Path]:
+def get_files_in_diff(target: str) -> list[Path]:
     """Return commit data & diff for target versus active code"""
+    git_root = GIT_ROOT.get()
+
     try:
         diff_content = subprocess.check_output(
             ["git", "diff", "--name-only", f"{target}", "--"], cwd=git_root, text=True
@@ -149,7 +158,9 @@ def get_files_in_diff(git_root: Path, target: str) -> list[Path]:
         raise UserError()
 
 
-def check_head_exists(git_root: Path) -> bool:
+def check_head_exists() -> bool:
+    git_root = GIT_ROOT.get()
+
     try:
         subprocess.check_output(["git", "rev-parse", "HEAD", "--"], cwd=git_root)
         return True
@@ -157,7 +168,9 @@ def check_head_exists(git_root: Path) -> bool:
         return False
 
 
-def get_default_branch(git_root: Path) -> str:
+def get_default_branch() -> str:
+    git_root = GIT_ROOT.get()
+
     try:
         # Fetch the symbolic ref of HEAD which points to the default branch
         default_branch = subprocess.check_output(

--- a/mentat/git_handler.py
+++ b/mentat/git_handler.py
@@ -1,9 +1,12 @@
 import logging
 import os
 import subprocess
+from contextvars import ContextVar
 from pathlib import Path
 
 from mentat.errors import UserError
+
+GIT_ROOT: ContextVar[Path] = ContextVar("mentat:git_root")
 
 
 def get_git_diff_for_path(git_root: Path, path: Path) -> str:

--- a/mentat/llm_api.py
+++ b/mentat/llm_api.py
@@ -1,6 +1,9 @@
+from __future__ import annotations
+
 import logging
 import os
 import sys
+from contextvars import ContextVar
 from dataclasses import dataclass
 from typing import Any, AsyncGenerator, Optional, cast
 
@@ -154,6 +157,9 @@ async def get_prompt_token_count(messages: list[dict[str, str]], model: str) -> 
                 color="yellow",
             )
     return prompt_token_count
+
+
+COST_TRACKER: ContextVar[CostTracker] = ContextVar("mentat:cost_tracker")
 
 
 @dataclass

--- a/mentat/parsers/block_parser.py
+++ b/mentat/parsers/block_parser.py
@@ -7,7 +7,6 @@ from typing import Any
 from typing_extensions import override
 
 from mentat.code_file_manager import CodeFileManager
-from mentat.config_manager import ConfigManager
 from mentat.errors import ModelError
 from mentat.parsers.change_display_helper import DisplayInformation, FileActionType
 from mentat.parsers.file_edit import FileEdit, Replacement
@@ -94,7 +93,7 @@ class BlockParser(Parser):
     def _special_block(
         self,
         code_file_manager: CodeFileManager,
-        config: ConfigManager,
+        git_root: Path,
         rename_map: dict[Path, Path],
         special_block: str,
     ) -> tuple[DisplayInformation, FileEdit, bool]:
@@ -166,7 +165,7 @@ class BlockParser(Parser):
         if deserialized_json.action == _BlockParserAction.Delete:
             replacements.append(Replacement(starting_line, ending_line, []))
         file_edit = FileEdit(
-            config.git_root / deserialized_json.file,
+            git_root / deserialized_json.file,
             replacements,
             is_creation=file_action == FileActionType.CreateFile,
             is_deletion=file_action == FileActionType.DeleteFile,

--- a/mentat/parsers/parser.py
+++ b/mentat/parsers/parser.py
@@ -1,16 +1,19 @@
+from __future__ import annotations
+
 import asyncio
 import logging
 from abc import ABC, abstractmethod
 from asyncio import Event
 from contextlib import asynccontextmanager
+from contextvars import ContextVar
 from pathlib import Path
 from typing import Any, AsyncGenerator
 
 from termcolor import colored
 
-from mentat.code_file_manager import CodeFileManager
-from mentat.config_manager import ConfigManager
+from mentat.code_file_manager import CODE_FILE_MANAGER, CodeFileManager
 from mentat.errors import ModelError
+from mentat.git_handler import GIT_ROOT
 from mentat.llm_api import chunk_to_lines
 from mentat.parsers.change_display_helper import (
     DisplayInformation,
@@ -24,6 +27,8 @@ from mentat.parsers.change_display_helper import (
 from mentat.parsers.file_edit import FileEdit
 from mentat.session_stream import SESSION_STREAM
 from mentat.streaming_printer import StreamingPrinter
+
+PARSER: ContextVar[Parser] = ContextVar("mentat:parser")
 
 
 class Parser(ABC):
@@ -58,8 +63,6 @@ class Parser(ABC):
     async def stream_and_parse_llm_response(
         self,
         response: AsyncGenerator[Any, None],
-        code_file_manager: CodeFileManager,
-        config: ConfigManager,
     ) -> tuple[str, list[FileEdit]]:
         """
         This general parsing structure relies on the assumption that all formats require three types of lines:
@@ -70,6 +73,9 @@ class Parser(ABC):
         """
 
         stream = SESSION_STREAM.get()
+        code_file_manager = CODE_FILE_MANAGER.get()
+        git_root = GIT_ROOT.get()
+
         printer = StreamingPrinter()
         printer_task = asyncio.create_task(printer.print_lines())
         message = ""
@@ -161,7 +167,7 @@ class Parser(ABC):
                                 file_edit,
                                 in_code_lines,
                             ) = self._special_block(
-                                code_file_manager, config, rename_map, cur_block
+                                code_file_manager, git_root, rename_map, cur_block
                             )
                         except ModelError as e:
                             printer.add_string(str(e), color="red")
@@ -186,8 +192,7 @@ class Parser(ABC):
                             )
                         if display_information.file_name in rename_map:
                             file_edit.file_path = (
-                                config.git_root
-                                / rename_map[display_information.file_name]
+                                git_root / rename_map[display_information.file_name]
                             )
 
                         # New file_edit creation and merging
@@ -341,7 +346,7 @@ class Parser(ABC):
     def _special_block(
         self,
         code_file_manager: CodeFileManager,
-        config: ConfigManager,
+        git_root: Path,
         rename_map: dict[Path, Path],
         special_block: str,
     ) -> tuple[DisplayInformation, FileEdit, bool]:

--- a/mentat/parsers/replacement_parser.py
+++ b/mentat/parsers/replacement_parser.py
@@ -3,7 +3,6 @@ from pathlib import Path
 from typing_extensions import override
 
 from mentat.code_file_manager import CodeFileManager
-from mentat.config_manager import ConfigManager
 from mentat.errors import ModelError
 from mentat.parsers.change_display_helper import DisplayInformation, FileActionType
 from mentat.parsers.file_edit import FileEdit, Replacement
@@ -34,7 +33,7 @@ class ReplacementParser(Parser):
     def _special_block(
         self,
         code_file_manager: CodeFileManager,
-        config: ConfigManager,
+        git_root: Path,
         rename_map: dict[Path, Path],
         special_block: str,
     ) -> tuple[DisplayInformation, FileEdit, bool]:
@@ -89,7 +88,7 @@ class ReplacementParser(Parser):
         )
 
         file_edit = FileEdit(
-            config.git_root / file_name,
+            git_root / file_name,
             [],
             is_creation=file_action_type == FileActionType.CreateFile,
             is_deletion=file_action_type == FileActionType.DeleteFile,

--- a/mentat/parsers/split_diff_parser.py
+++ b/mentat/parsers/split_diff_parser.py
@@ -5,7 +5,6 @@ from termcolor import colored
 from typing_extensions import override
 
 from mentat.code_file_manager import CodeFileManager
-from mentat.config_manager import ConfigManager
 from mentat.parsers.change_display_helper import DisplayInformation, FileActionType
 from mentat.parsers.file_edit import FileEdit, Replacement
 from mentat.parsers.parser import Parser
@@ -72,7 +71,7 @@ class SplitDiffParser(Parser):
     def _special_block(
         self,
         code_file_manager: CodeFileManager,
-        config: ConfigManager,
+        git_root: Path,
         rename_map: dict[Path, Path],
         special_block: str,
     ) -> tuple[DisplayInformation, FileEdit, bool]:
@@ -109,7 +108,7 @@ class SplitDiffParser(Parser):
             new_name=new_name,
         )
         file_edit = FileEdit(
-            config.git_root / file_name, [], is_creation, is_deletion, new_name
+            git_root / file_name, [], is_creation, is_deletion, new_name
         )
         return (
             display_information,

--- a/mentat/session.py
+++ b/mentat/session.py
@@ -6,17 +6,17 @@ from pathlib import Path
 from typing import List, Optional, Union, cast
 from uuid import uuid4
 
-from .code_context import CodeContext, CodeContextSettings
+from .code_context import CODE_CONTEXT, CodeContext, CodeContextSettings
 from .code_edit_feedback import get_user_feedback_on_edits
-from .code_file_manager import CodeFileManager
+from .code_file_manager import CODE_FILE_MANAGER, CodeFileManager
 from .commands import Command
-from .config_manager import ConfigManager
-from .conversation import Conversation
+from .config_manager import CONFIG_MANAGER, ConfigManager
+from .conversation import CONVERSATION, Conversation
 from .errors import MentatError
-from .git_handler import get_shared_git_root_for_paths
-from .llm_api import CostTracker, setup_api_key
+from .git_handler import GIT_ROOT, get_shared_git_root_for_paths
+from .llm_api import COST_TRACKER, CostTracker, setup_api_key
 from .parsers.block_parser import BlockParser
-from .parsers.parser import Parser
+from .parsers.parser import PARSER, Parser
 from .parsers.replacement_parser import ReplacementParser
 from .parsers.split_diff_parser import SplitDiffParser
 from .session_input import collect_user_input
@@ -33,18 +33,10 @@ class Session:
     def __init__(
         self,
         stream: SessionStream,
-        config: ConfigManager,
-        parser: Parser,
-        code_context_settings: Optional[CodeContextSettings] = None,
     ):
         self.stream = stream
-        self.config = config
-        self.parser = parser
-        self.code_context_settings = code_context_settings or CodeContextSettings()
 
         self.id = uuid4()
-        self.code_file_manager = CodeFileManager(self.config)
-        self.cost_tracker = CostTracker()
         setup_api_key()
 
         self._main_task: asyncio.Task[None] | None = None
@@ -59,44 +51,54 @@ class Session:
         diff: Optional[str] = None,
         pr_diff: Optional[str] = None,
     ):
+        # Set contextvars here
         stream = SessionStream()
         await stream.start()
         SESSION_STREAM.set(stream)
 
+        cost_tracker = CostTracker()
+        COST_TRACKER.set(cost_tracker)
+
         git_root = get_shared_git_root_for_paths([Path(path) for path in paths])
+        GIT_ROOT.set(git_root)
+
         # TODO: Config should be created in the client (i.e., to get vscode settings) and passed to session
-        config = await ConfigManager.create(git_root)
+        config = await ConfigManager.create()
+        CONFIG_MANAGER.set(config)
+
+        parser = parser_map[config.parser()]
+        PARSER.set(parser)
+
         code_context_settings = CodeContextSettings(
             paths, exclude_paths, diff, pr_diff, no_code_map
         )
-        parser = parser_map[config.parser()]
+        code_context = await CodeContext.create(code_context_settings)
+        CODE_CONTEXT.set(code_context)
 
-        self = Session(stream, config, parser, code_context_settings)
+        # NOTE: Should codefilemanager, codecontext, and conversation be contextvars/singletons or regular instances?
+        code_file_manager = CodeFileManager()
+        CODE_FILE_MANAGER.set(code_file_manager)
 
+        conversation = Conversation()
+        CONVERSATION.set(conversation)
+
+        self = Session(stream)
         return self
 
     async def _main(self):
-        try:
-            self.code_context = await CodeContext.create(
-                self.config, **self.code_context_settings.asdict()
-            )
-            await self.code_context.display_context()
+        stream = SESSION_STREAM.get()
+        code_context = CODE_CONTEXT.get()
+        conversation = CONVERSATION.get()
 
-            conv = await Conversation.create(
-                parser=self.parser,
-                config=self.config,
-                cost_tracker=self.cost_tracker,
-                code_context=self.code_context,
-                code_file_manager=self.code_file_manager,
-            )
+        try:
+            await code_context.display_context()
+            await conversation.display_token_count()
         except MentatError as e:
-            await self.stream.send(str(e), color="red")
+            await stream.send(str(e), color="red")
             return
 
-        await self.stream.send(
-            "Type 'q' or use Ctrl-C to quit at any time.", color="cyan"
-        )
-        await self.stream.send("What can I do for you?", color="light_blue")
+        await stream.send("Type 'q' or use Ctrl-C to quit at any time.", color="cyan")
+        await stream.send("What can I do for you?", color="light_blue")
         need_user_request = True
         while True:
             if need_user_request:
@@ -105,29 +107,21 @@ class Session:
                 # Intercept and run command
                 if isinstance(message.data, str) and message.data.startswith("/"):
                     arguments = shlex.split(message.data[1:])
-                    command = Command.create_command(arguments[0], self.code_context)
+                    command = Command.create_command(arguments[0])
                     await command.apply(*arguments[1:])
                     continue
 
                 if message.data == "q":
                     break
 
-                conv.add_user_message(message.data)
+                conversation.add_user_message(message.data)
 
-            file_edits = await conv.get_model_response(self.parser, self.config)
+            file_edits = await conversation.get_model_response()
             file_edits = [
-                file_edit
-                for file_edit in file_edits
-                if await file_edit.is_valid(self.code_file_manager, self.config)
+                file_edit for file_edit in file_edits if await file_edit.is_valid()
             ]
             if file_edits:
-                need_user_request = await get_user_feedback_on_edits(
-                    config=self.config,
-                    conv=conv,
-                    code_file_manager=self.code_file_manager,
-                    code_context=self.code_context,
-                    file_edits=file_edits,
-                )
+                need_user_request = await get_user_feedback_on_edits(file_edits)
             else:
                 need_user_request = True
 
@@ -186,10 +180,12 @@ class Session:
             return
 
         async def run_stop():
+            cost_tracker = COST_TRACKER.get()
+
             if self._main_task is None:
                 return
             try:
-                await self.cost_tracker.display_total_cost()
+                await cost_tracker.display_total_cost()
                 self._main_task.cancel()
 
                 # Pyright can't see `self._main_task` being set to `None` in the task

--- a/mentat/session.py
+++ b/mentat/session.py
@@ -82,8 +82,7 @@ class Session:
         conversation = Conversation()
         CONVERSATION.set(conversation)
 
-        self = Session(stream)
-        return self
+        return cls(stream)
 
     async def _main(self):
         stream = SESSION_STREAM.get()

--- a/mentat/terminal/client.py
+++ b/mentat/terminal/client.py
@@ -12,6 +12,7 @@ from prompt_toolkit.styles import Style
 from termcolor import cprint
 
 from mentat.code_file import parse_intervals
+from mentat.config_manager import CONFIG_MANAGER
 from mentat.logging_config import setup_logging
 from mentat.session import Session
 from mentat.session_stream import StreamMessageSource
@@ -118,11 +119,8 @@ class TerminalClient:
             self.paths, self.exclude_paths, self.no_code_map, self.diff, self.pr_diff
         )
         self.session.start()
-
-        mentat_completer = MentatCompleter(self.session)
-        self._prompt_session = MentatPromptSession(
-            self.session, completer=mentat_completer
-        )
+        mentat_completer = MentatCompleter()
+        self._prompt_session = MentatPromptSession(completer=mentat_completer)
 
         plain_bindings = KeyBindings()
 
@@ -136,7 +134,7 @@ class TerminalClient:
 
         self._plain_session = PromptSession[str](
             message=[("class:prompt", ">>> ")],
-            style=Style(self.session.config.input_style()),
+            style=Style(CONFIG_MANAGER.get().input_style()),
             completer=None,
             key_bindings=plain_bindings,
         )

--- a/mentat/terminal/prompt_completer.py
+++ b/mentat/terminal/prompt_completer.py
@@ -14,8 +14,8 @@ from pygments.lexers import guess_lexer_for_filename
 from pygments.token import Token
 from pygments.util import ClassNotFound
 
+from mentat.code_context import CODE_CONTEXT
 from mentat.commands import Command
-from mentat.session import Session
 
 
 @dataclass
@@ -25,9 +25,7 @@ class SyntaxCompletion:
 
 
 class MentatCompleter(Completer):
-    def __init__(self, session: Session):
-        self.session = session
-
+    def __init__(self):
         self.syntax_completions: Dict[Path, SyntaxCompletion] = dict()
         self.file_name_completions: DefaultDict[str, Set[Path]] = defaultdict(set)
         self.command_completer = WordCompleter(
@@ -67,7 +65,9 @@ class MentatCompleter(Completer):
         self.syntax_completions[file_path] = SyntaxCompletion(words=filtered_tokens)
 
     async def refresh_completions(self):
-        file_paths = list(self.session.code_context.files.keys())
+        code_context = CODE_CONTEXT.get()
+
+        file_paths = list(code_context.files.keys())
 
         # Remove syntax completions for files not in the context
         for file_path in set(self.syntax_completions.keys()):

--- a/mentat/terminal/prompt_session.py
+++ b/mentat/terminal/prompt_session.py
@@ -12,8 +12,7 @@ from prompt_toolkit.key_binding import KeyBindings
 from prompt_toolkit.key_binding.key_processor import KeyPressEvent
 from prompt_toolkit.styles import Style
 
-from mentat.config_manager import mentat_dir_path
-from mentat.session import Session
+from mentat.config_manager import CONFIG_MANAGER, mentat_dir_path
 
 
 class FilteredFileHistory(FileHistory):
@@ -44,11 +43,11 @@ class FilteredHistorySuggestions(AutoSuggestFromHistory):
 
 
 class MentatPromptSession(PromptSession[str]):
-    def __init__(self, session: Session, *args: Any, **kwargs: Any):
+    def __init__(self, *args: Any, **kwargs: Any):
         self._setup_bindings()
         super().__init__(
             message=[("class:prompt", ">>> ")],
-            style=Style(session.config.input_style()),
+            style=Style(CONFIG_MANAGER.get().input_style()),
             history=FilteredFileHistory(str(mentat_dir_path.joinpath("history"))),
             auto_suggest=FilteredHistorySuggestions(),
             multiline=True,

--- a/tests/code_context_test.py
+++ b/tests/code_context_test.py
@@ -4,14 +4,15 @@ from unittest import TestCase
 
 import pytest
 
-from mentat.code_context import CodeContext
 from mentat.config_manager import ConfigManager
 from mentat.errors import UserError
 from mentat.terminal.client import expand_paths
 
 
 @pytest.mark.asyncio
-async def test_path_gitignoring(mock_stream, temp_testbed, mock_config):
+async def test_path_gitignoring(
+    temp_testbed, mock_stream, mock_config, mock_code_context
+):
     gitignore_path = ".gitignore"
     testing_dir_path = "git_testing_dir"
     os.makedirs(testing_dir_path)
@@ -30,9 +31,8 @@ async def test_path_gitignoring(mock_stream, temp_testbed, mock_config):
 
     # Run CodeFileManager on the git_testing_dir, and also explicitly pass in ignored_file_2.txt
     paths = [testing_dir_path, ignored_file_path_2]
-    code_context = await CodeContext.create(
-        config=mock_config, paths=paths, exclude_paths=[]
-    )
+    mock_code_context.settings.paths = paths
+    await mock_code_context.refresh(True)
 
     expected_file_paths = [
         os.path.join(temp_testbed, ignored_file_path_2),
@@ -40,12 +40,14 @@ async def test_path_gitignoring(mock_stream, temp_testbed, mock_config):
     ]
 
     case = TestCase()
-    file_paths = [str(file_path.resolve()) for file_path in code_context.files]
+    file_paths = [str(file_path.resolve()) for file_path in mock_code_context.files]
     case.assertListEqual(sorted(expected_file_paths), sorted(file_paths))
 
 
 @pytest.mark.asyncio
-async def test_config_glob_exclude(mock_stream, mocker, temp_testbed, mock_config):
+async def test_config_glob_exclude(
+    mocker, temp_testbed, mock_stream, mock_config, mock_code_context
+):
     # Makes sure glob exclude config works
     mock_glob_exclude = mocker.MagicMock()
     mocker.patch.object(ConfigManager, "file_exclude_glob_list", new=mock_glob_exclude)
@@ -68,19 +70,17 @@ async def test_config_glob_exclude(mock_stream, mocker, temp_testbed, mock_confi
             "Config excludes me but I'm included if added directly"
         )
 
-    code_context = await CodeContext.create(
-        config=mock_config,
-        paths=[Path("."), directly_added_glob_excluded_path],
-        exclude_paths=[],
-    )
-    file_paths = [str(file_path.resolve()) for file_path in code_context.files]
+    mock_code_context.settings.paths = [Path("."), directly_added_glob_excluded_path]
+    await mock_code_context.refresh(True)
+
+    file_paths = [str(file_path.resolve()) for file_path in mock_code_context.files]
     assert os.path.join(temp_testbed, glob_exclude_path) not in file_paths
     assert os.path.join(temp_testbed, glob_include_path) in file_paths
     assert os.path.join(temp_testbed, directly_added_glob_excluded_path) in file_paths
 
 
 @pytest.mark.asyncio
-async def test_glob_include(mock_stream, temp_testbed, mock_config):
+async def test_glob_include(temp_testbed, mock_stream, mock_config, mock_code_context):
     # Make sure glob include works
     glob_include_path = os.path.join("glob_test", "bagel", "apple", "include_me.py")
     glob_include_path2 = os.path.join("glob_test", "bagel", "apple", "include_me2.py")
@@ -97,19 +97,19 @@ async def test_glob_include(mock_stream, temp_testbed, mock_config):
         glob_exclude_file.write("I am not included")
 
     file_paths = expand_paths(["**/*.py"])
-    code_context = await CodeContext.create(
-        config=mock_config,
-        paths=file_paths,
-        exclude_paths=[],
-    )
-    file_paths = [str(file_path.resolve()) for file_path in code_context.files]
+    mock_code_context.settings.paths = file_paths
+    await mock_code_context.refresh(True)
+
+    file_paths = [str(file_path.resolve()) for file_path in mock_code_context.files]
     assert os.path.join(temp_testbed, glob_exclude_path) not in file_paths
     assert os.path.join(temp_testbed, glob_include_path) in file_paths
     assert os.path.join(temp_testbed, glob_include_path2) in file_paths
 
 
 @pytest.mark.asyncio
-async def test_cli_glob_exclude(mock_stream, temp_testbed, mock_config):
+async def test_cli_glob_exclude(
+    temp_testbed, mock_stream, mock_config, mock_code_context
+):
     # Make sure cli glob exclude works and overrides regular include
     glob_include_then_exclude_path = os.path.join(
         "glob_test", "bagel", "apple", "include_then_exclude_me.py"
@@ -125,32 +125,28 @@ async def test_cli_glob_exclude(mock_stream, temp_testbed, mock_config):
 
     file_paths = expand_paths(["**/*.py"])
     exclude_paths = expand_paths(["**/*.py", "**/*.ts"])
-    code_context = await CodeContext.create(
-        config=mock_config,
-        paths=file_paths,
-        exclude_paths=exclude_paths,
-    )
+    mock_code_context.settings.paths = file_paths
+    mock_code_context.settings.exclude_paths = exclude_paths
+    await mock_code_context.refresh(True)
 
-    file_paths = [file_path for file_path in code_context.files]
+    file_paths = [file_path for file_path in mock_code_context.files]
     assert os.path.join(temp_testbed, glob_include_then_exclude_path) not in file_paths
     assert os.path.join(temp_testbed, glob_exclude_path) not in file_paths
 
 
 @pytest.mark.asyncio
-async def test_text_encoding_checking(mock_stream, temp_testbed, mock_config):
+async def test_text_encoding_checking(
+    temp_testbed, mock_stream, mock_config, mock_code_context
+):
     # Makes sure we don't include non text encoded files, and we quit if user gives us one
     nontext_path = "iamnottext.py"
     with open(nontext_path, "wb") as f:
         # 0x81 is invalid in UTF-8 (single byte > 127), and undefined in cp1252 and iso-8859-1
         f.write(bytearray([0x81]))
 
-    paths = [Path("./")]
-    code_context = await CodeContext.create(
-        config=mock_config,
-        paths=paths,
-        exclude_paths=[],
-    )
-    file_paths = [file_path for file_path in code_context.files]
+    mock_code_context.settings.paths = [Path("./")]
+    await mock_code_context.refresh(True)
+    file_paths = [file_path for file_path in mock_code_context.files]
     assert os.path.join(temp_testbed, nontext_path) not in file_paths
 
     with pytest.raises(UserError) as e_info:
@@ -160,9 +156,6 @@ async def test_text_encoding_checking(mock_stream, temp_testbed, mock_config):
             f.write(bytearray([0x81]))
 
         paths = [Path(nontext_path_requested)]
-        _ = await CodeContext.create(
-            config=mock_config,
-            paths=paths,
-            exclude_paths=[],
-        )
+        mock_code_context.settings.paths = paths
+        await mock_code_context.refresh(True)
     assert e_info.type == UserError

--- a/tests/commands_test.py
+++ b/tests/commands_test.py
@@ -3,7 +3,6 @@ from pathlib import Path
 
 import pytest
 
-from mentat.code_context import CodeContext
 from mentat.commands import (
     AddCommand,
     Command,
@@ -36,26 +35,17 @@ async def test_commit_command(mock_stream, temp_testbed):
 
 
 @pytest.mark.asyncio
-async def test_add_command(mock_stream, mock_config):
-    code_context = await CodeContext.create(
-        config=mock_config,
-        paths=[],
-        exclude_paths=[],
-    )
-    command = Command.create_command("add", code_context=code_context)
+async def test_add_command(mock_stream, mock_config, mock_code_context):
+    command = Command.create_command("add")
     assert isinstance(command, AddCommand)
     await command.apply("__init__.py")
-    assert Path("__init__.py") in code_context.files
+    assert Path("__init__.py") in mock_code_context.files
 
 
 @pytest.mark.asyncio
-async def test_remove_command(mock_stream, mock_config):
-    code_context = await CodeContext.create(
-        config=mock_config,
-        paths=[Path("__init__.py")],
-        exclude_paths=[],
-    )
-    command = Command.create_command("remove", code_context=code_context)
+async def test_remove_command(mock_stream, mock_config, mock_code_context):
+    mock_code_context.settings.paths = [Path("__init__.py")]
+    command = Command.create_command("remove")
     assert isinstance(command, RemoveCommand)
     await command.apply("__init__.py")
-    assert Path("__init__.py") not in code_context.files
+    assert Path("__init__.py") not in mock_code_context.files

--- a/tests/config_test.py
+++ b/tests/config_test.py
@@ -1,4 +1,3 @@
-from pathlib import Path
 from textwrap import dedent
 
 import pytest
@@ -7,7 +6,7 @@ from mentat.config_manager import ConfigManager, config_file_name
 
 
 @pytest.mark.asyncio
-async def test_config_priority(mock_stream, temp_testbed):
+async def test_config_priority(temp_testbed, mock_stream, mock_git_root):
     # First project config should be considered, then user config, then default config, then error
     with open(config_file_name, "w") as project_config_file:
         project_config_file.write(dedent("""\
@@ -17,7 +16,7 @@ async def test_config_priority(mock_stream, temp_testbed):
 
     # Since we don't want to actually change user config file or default config file,
     # we have to just mock them
-    config = await ConfigManager.create(Path(temp_testbed))
+    config = await ConfigManager.create()
     config.user_config = {"project-first": "I will not be used", "user-second": "user"}
     config.default_config = {
         "project-first": "I also am not used",
@@ -35,7 +34,7 @@ async def test_config_priority(mock_stream, temp_testbed):
 
 
 @pytest.mark.asyncio
-async def test_invalid_config(mock_stream, temp_testbed):
+async def test_invalid_config(temp_testbed, mock_stream, mock_git_root):
     # If invalid config file is found, it should use next config
     with open(config_file_name, "w") as project_config_file:
         project_config_file.write(dedent("""\
@@ -44,6 +43,6 @@ async def test_invalid_config(mock_stream, temp_testbed):
             "invalid-json: []]
         }"""))
 
-    config = await ConfigManager.create(Path(temp_testbed))
+    config = await ConfigManager.create()
     config.user_config = {"mykey": "user"}
     assert config._get_key("mykey") == "user"


### PR DESCRIPTION
Moves git root out of config and turns all of the singletons into contextvars, instead of passing them around everywhere. 

Couple of notes:

I removed the 'self.config', 'self.code_file_manager', etc. references everywhere except for the Session still having self.stream; we can change that in the future if we need to, but with the upcoming RFC server change, I decided to wait until we know what it's all going to look like.

Do you think we should have CodeFileManager, CodeContext, and Conversation be regular instances? We might want to have multiple of them in the future. On the other hand, I think it makes a lot more sense in our current codebase for them to be singletons. Let me know what y'all think!