### PR TITLE
A recursive FileNode for CodeFileManager

### DIFF
--- a/mentat/file_node.py
+++ b/mentat/file_node.py
@@ -1,0 +1,92 @@
+from __future__ import annotations
+
+import asyncio
+from pathlib import Path
+from typing import Generator
+
+from mentat.errors import MentatError
+from mentat.git_handler import get_non_gitignored_files
+from mentat.utils import sha256
+
+
+class Node:
+    def __init__(self, path: Path, parent: Node | None = None):
+        self.path = path.resolve()
+        self.parent = parent
+        self.children = dict[str, Node]()
+        self.lock = asyncio.Lock()
+        self.refresh()
+
+    def __getitem__(self, path: Path | str) -> "Node":
+        if isinstance(path, str):
+            path = Path(path)
+        if path.is_absolute():
+            path = path.relative_to(self.root().path)
+        if path == Path("."):
+            return self
+
+        stem = path.parts[0]
+        if stem not in self.children:
+            raise KeyError(f"Node {self.path} has no child {stem}")
+        elif len(path.parts) == 1:
+            return self.children[stem]
+        else:
+            return self.children[stem][Path(*path.parts[1:])]
+
+    def iter_nodes(
+        self, include_dirs: bool = True, include_files: bool = True
+    ) -> Generator[Node, None, None]:
+        if self.path.is_dir():
+            if include_dirs:
+                yield self
+            for child in self.children.values():
+                yield from child.iter_nodes(include_dirs, include_files)
+        elif include_files:
+            yield self
+
+    def refresh(self):
+        if self.path.is_dir():
+            tracked_children = {p.parts[0] for p in get_non_gitignored_files(self.path)}
+            untracked_children = (
+                set(self.children.keys()) - tracked_children
+            )  # Added manually
+            all_children = tracked_children.union(untracked_children)
+            for child in sorted(all_children):
+                if child in self.children:
+                    self.children[child].refresh()
+                else:
+                    self.children[child] = Node(Path(self.path / child), self)
+
+    def root(self) -> "Node":
+        return self if self.parent is None else self.parent.root()
+
+    def relative_path(self) -> Path:
+        return self.path.relative_to(self.root().path)
+
+    def display(self, prefix: str = ""):
+        print(prefix + self.path.name)
+        for child in self.children.values():
+            child.display(prefix + "  ")
+
+    async def read_text(self) -> str:
+        if self.path.is_dir():
+            raise MentatError(f"Cannot read text from directory {self.path}")
+        async with self.lock:
+            return self.path.read_text()
+
+    async def write_text(self, text: str):
+        if self.path.is_dir():
+            raise MentatError(f"Cannot write text to directory {self.path}")
+        async with self.lock:
+            self.path.write_text(text)
+
+    async def get_checksum(self) -> str:
+        if self.path.is_dir():
+            _checksums = dict[str, str]()
+            for name in sorted(self.children.keys()):
+                _c = await self.children[name].get_checksum()
+                _checksums[name] = _c
+            return sha256(str(_checksums))
+        else:
+            text = await self.read_text()
+            return sha256(text)

--- a/mentat/utils.py
+++ b/mentat/utils.py
@@ -1,4 +1,9 @@
 import asyncio
+import hashlib
+
+
+def sha256(data: str) -> str:
+    return hashlib.sha256(data.encode("utf-8")).hexdigest()
 
 
 async def run_subprocess_async(*args: str) -> str:

--- a/tests/file_node_test.py
+++ b/tests/file_node_test.py
@@ -1,0 +1,56 @@
+from asyncio import gather
+from pathlib import Path
+
+import pytest
+
+from mentat.file_node import Node
+
+
+def test_node_init(temp_testbed):
+    root_path = Path(temp_testbed)
+    root = Node(root_path)
+    assert root.path == root_path
+    assert len(root.children) > 1
+
+    # Initialize and iterate over all children, depth-first, alphabetically
+    all_children = list(r.relative_path() for r in root.iter_nodes())
+    expected = [
+        ".",
+        ".gitignore",
+        "__init__.py",
+        "multifile_calculator",
+        "multifile_calculator/__init__.py",
+        "multifile_calculator/calculator.py",
+        "multifile_calculator/operations.py",
+        "scripts",
+        "scripts/calculator.py",
+        "scripts/echo.py",
+        "scripts/graph_class.py",
+    ]
+    assert all_children == [Path(e) for e in expected]
+
+    # Access children by relative path, absolute path or string
+    echo = root["scripts/echo.py"]
+    echo2 = root[Path("scripts/echo.py")]
+    echo3 = root[Path("scripts/echo.py").absolute()]
+    assert echo == echo2 == echo3
+
+    assert echo.root().path.name == root.path.name
+    assert echo.relative_path() == Path("scripts/echo.py")
+
+
+@pytest.mark.asyncio
+async def test_node_checksum(temp_testbed):
+    root_path = Path(temp_testbed)
+    root = Node(root_path)
+    echo = root["scripts/echo.py"]
+    unaffected = root["multifile_calculator"]
+
+    # Checksums work on files or directories
+    initial_checksum = await echo.get_checksum()
+    initial_unaffected = await unaffected.get_checksum()
+    await echo.write_text("Updated text")
+    new_checksum = await echo.get_checksum()
+    new_unaffected = await unaffected.get_checksum()
+    assert initial_checksum != new_checksum
+    assert initial_unaffected == new_unaffected


### PR DESCRIPTION
I have mentioned this in a couple comments so here is a start. I'm imagining:
- `CodeFileManager.root` is a Node for the git_root. This can be built and cached on startup.
- `CodeFile` and `FileEdit` can get the node via `CODE_FILE_MANAGER.get().root[path]`, and then use it for thread-safe read/write. We'll set CFM outside/above the session loops.
- Everything in `include_files.py` can be done here much easier.

So this is here as a draft for feedback. Planning to build it out after #115.
