### PR TITLE
Python client added

### DIFF
--- a/mentat/python_client/client.py
+++ b/mentat/python_client/client.py
@@ -27,11 +27,11 @@ class PythonClient:
         self.acc_task: asyncio.Task[None] | None = None
         self._started = False
         self._accumulated_message = ""
-        self._input_request_message = None
 
     async def call_mentat(self, message: str):
         if not self._started:
             await self._startup()
+        assert isinstance(self.session, Session), "Client is not running"
         await self.session.stream.send(
             message,
             source=StreamMessageSource.CLIENT,
@@ -63,7 +63,7 @@ class PythonClient:
 
     async def stop(self):
         if self.session is not None:
-            await self.session.stop()
+            self.session.stop()
             self.session = None
         if self.acc_task is not None:
             self.acc_task.cancel()

--- a/mentat/python_client/client.py
+++ b/mentat/python_client/client.py
@@ -59,9 +59,8 @@ class PythonClient:
             self.paths, self.exclude_paths, self.no_code_map, self.diff, self.pr_diff
         )
         asyncio.ensure_future(self.session.start())
-        self._input_request_message = await self.session.stream.recv("input_request")
-
         self.acc_task = asyncio.create_task(self._accumulate_messages())
+        self._input_request_message = await self.session.stream.recv("input_request")
         self._started = True
 
     async def stop(self):

--- a/mentat/python_client/client.py
+++ b/mentat/python_client/client.py
@@ -1,0 +1,71 @@
+import asyncio
+from pathlib import Path
+from typing import List, Set
+
+from mentat.session import Session
+from mentat.session_stream import StreamMessageSource
+
+
+class PythonClient:
+    def __init__(
+        self,
+        paths: List[Path] = [],
+        exclude_paths: List[Path] = [],
+        no_code_map: bool = False,
+        diff: str | None = None,
+        pr_diff: str | None = None,
+    ):
+        self.paths = paths
+        self.exclude_paths = exclude_paths
+        self.no_code_map = no_code_map
+        self.diff = diff
+        self.pr_diff = pr_diff
+
+        self.session: Session | None = None
+
+        self._tasks: Set[asyncio.Task[None]] = set()
+        self.acc_task: asyncio.Task[None] | None = None
+        self._started = False
+        self._accumulated_message = ""
+        self._input_request_message = None
+
+    async def call_mentat(self, message: str):
+        if not self._started:
+            await self._startup()
+        await self.session.stream.send(
+            message,
+            source=StreamMessageSource.CLIENT,
+            channel=f"input_request:{self._input_request_message.id}",
+        )
+        self._input_request_message = await self.session.stream.recv("input_request")
+        temp = self._accumulated_message
+        self._accumulated_message = ""
+        return temp
+
+    async def call_mentat_auto_accept(self, message: str):
+        await self.call_mentat(message)
+        await self.call_mentat("y")
+
+    async def _accumulate_messages(self):
+        assert isinstance(self.session, Session), "Client is not running"
+        async for message in self.session.stream.listen():
+            self._accumulated_message += message.data
+
+    async def _startup(self):
+        self.session = await Session.create(
+            self.paths, self.exclude_paths, self.no_code_map, self.diff, self.pr_diff
+        )
+        asyncio.ensure_future(self.session.start())
+        self._input_request_message = await self.session.stream.recv("input_request")
+
+        self.acc_task = asyncio.create_task(self._accumulate_messages())
+        self._started = True
+
+    async def stop(self):
+        if self.session is not None:
+            await self.session.stop()
+            self.session = None
+        if self.acc_task is not None:
+            self.acc_task.cancel()
+            self.acc_task = None
+        self._started = False

--- a/mentat/python_client/client.py
+++ b/mentat/python_client/client.py
@@ -49,7 +49,10 @@ class PythonClient:
     async def _accumulate_messages(self):
         assert isinstance(self.session, Session), "Client is not running"
         async for message in self.session.stream.listen():
-            self._accumulated_message += message.data
+            end = "\n"
+            if message.extra and isinstance(message.extra.get("end"), str):
+                end = message.extra["end"]
+            self._accumulated_message += message.data + end
 
     async def _startup(self):
         self.session = await Session.create(

--- a/tests/clients/python_client_test.py
+++ b/tests/clients/python_client_test.py
@@ -1,0 +1,61 @@
+from textwrap import dedent
+
+import pytest
+
+from mentat.python_client.client import PythonClient
+
+
+@pytest.mark.asyncio
+async def test_editing_file_auto_accept(mock_call_llm_api, mock_setup_api_key):
+    file_name = "test.py"
+    with open(file_name, "w") as f:
+        f.write("# Line 1")
+
+    mock_call_llm_api.set_generator_values([dedent(f"""\
+        Conversation
+
+        @@start
+        {{
+            "file": "{file_name}",
+            "action": "insert",
+            "insert-before-line": 2,
+            "insert-after-line": 1
+        }}
+        @@code
+        # Line 2
+        @@end""")])
+
+    python_client = PythonClient(["."])
+    await python_client.call_mentat_auto_accept("Conversation")
+    with open(file_name, "r") as f:
+        content = f.read()
+        expected_content = "# Line 1\n# Line 2"
+    assert content == expected_content
+    await python_client.stop()
+
+
+@pytest.mark.asyncio
+async def test_collects_mentat_response(mock_call_llm_api, mock_setup_api_key):
+    file_name = "test.py"
+    with open(file_name, "w") as f:
+        f.write("# Line 1")
+
+    mock_call_llm_api.set_generator_values([dedent(f"""\
+        Conversation
+
+        @@start
+        {{
+            "file": "{file_name}",
+            "action": "insert",
+            "insert-before-line": 2,
+            "insert-after-line": 1
+        }}
+        @@code
+        # Line 2
+        @@end""")])
+
+    python_client = PythonClient(["."])
+    response = await python_client.call_mentat("Conversation")
+    assert "Conversation" in response
+    assert "Apply these changes? 'Y/n/i' or provide feedback." in response
+    await python_client.stop()


### PR DESCRIPTION
A light client for mentat is created and used in the exercism test. I think we'll mostly find value in this for testing but I could imagine people wanting to interact with mentat programmatically. For instance maybe you want to give GPT-4 access to mentat.