### PR TITLE
use signal.signal instead of loop.add_signal_handler

### DIFF
--- a/mentat/terminal/client.py
+++ b/mentat/terminal/client.py
@@ -89,6 +89,9 @@ class TerminalClient:
             "", source=StreamMessageSource.CLIENT, channel="interrupt"
         )
 
+    # Be careful editing this function; since we use signal.signal instead of asyncio's
+    # add signal handler (which isn't available on Windows), this function can interrupt
+    # asyncio coroutines, potentially causing race conditions.
     def _handle_exit(self, sig: int, frame: FrameType | None):
         assert isinstance(self.session, Session), "TerminalClient is not running"
         if (

--- a/mentat/terminal/client.py
+++ b/mentat/terminal/client.py
@@ -3,6 +3,7 @@ import asyncio
 import logging
 import signal
 from pathlib import Path
+from types import FrameType
 from typing import Any, Coroutine, List, Set
 
 from prompt_toolkit import PromptSession
@@ -88,7 +89,7 @@ class TerminalClient:
             "", source=StreamMessageSource.CLIENT, channel="interrupt"
         )
 
-    def _handle_exit(self, sig, frame):
+    def _handle_exit(self, sig: int, frame: FrameType | None):
         assert isinstance(self.session, Session), "TerminalClient is not running"
         if (
             self.session.is_stopped

--- a/mentat/terminal/client.py
+++ b/mentat/terminal/client.py
@@ -88,7 +88,7 @@ class TerminalClient:
             "", source=StreamMessageSource.CLIENT, channel="interrupt"
         )
 
-    def _handle_exit(self):
+    def _handle_exit(self, sig, frame):
         assert isinstance(self.session, Session), "TerminalClient is not running"
         if (
             self.session.is_stopped
@@ -106,8 +106,7 @@ class TerminalClient:
             self._create_task(self._send_session_stream_interrupt())
 
     def _init_signal_handlers(self):
-        loop = asyncio.get_event_loop()
-        loop.add_signal_handler(signal.SIGINT, self._handle_exit)
+        signal.signal(signal.SIGINT, self._handle_exit)
 
     async def _startup(self):
         assert self.session is None, "TerminalClient already running"

--- a/tests/clients/terminal_client_test.py
+++ b/tests/clients/terminal_client_test.py
@@ -1,3 +1,4 @@
+import os
 import subprocess
 from textwrap import dedent
 from unittest.mock import AsyncMock
@@ -8,8 +9,17 @@ from prompt_toolkit import PromptSession
 from mentat.terminal.client import TerminalClient
 
 
+def mock_init(self, *args, **kwargs):
+    return None
+
+
 @pytest.fixture
 def mock_prompt_session_prompt(mocker):
+    # On Github Actions Windows runners (not on actual Windows!) just instantiating a PromptToolkit instance
+    # causes a crash, so we have to completely mock the PromptSession
+    if os.name == "nt":
+        mocker.patch.object(PromptSession, "__init__", new=mock_init)
+
     mock_method = AsyncMock()
     mocker.patch.object(PromptSession, "prompt_async", new=mock_method)
     return mock_method

--- a/tests/clients/terminal_client_test.py
+++ b/tests/clients/terminal_client_test.py
@@ -1,4 +1,3 @@
-import os
 import subprocess
 from textwrap import dedent
 from unittest.mock import AsyncMock
@@ -7,12 +6,6 @@ import pytest
 from prompt_toolkit import PromptSession
 
 from mentat.terminal.client import TerminalClient
-
-# Unfortunately these tests just can't be run on Windows
-pytestmark = pytest.mark.skipif(
-    os.name == "nt",
-    reason="PromptSession throws an error on Github Actions Windows runner",
-)
 
 
 @pytest.fixture

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -11,9 +11,10 @@ from uuid import uuid4
 import pytest
 import pytest_asyncio
 
+from mentat import config_manager
 from mentat.code_context import CODE_CONTEXT, CodeContext, CodeContextSettings
 from mentat.code_file_manager import CODE_FILE_MANAGER, CodeFileManager
-from mentat.config_manager import CONFIG_MANAGER, ConfigManager
+from mentat.config_manager import CONFIG_MANAGER, ConfigManager, config_file_name
 from mentat.git_handler import GIT_ROOT
 from mentat.parsers.block_parser import BlockParser
 from mentat.parsers.parser import PARSER
@@ -298,9 +299,6 @@ def temp_testbed(monkeypatch):
 # it will be unset unless a specific test wants to make a config in the testbed
 @pytest.fixture(autouse=True)
 def mock_user_config(mocker):
-    from mentat import config_manager
-    from mentat.config_manager import config_file_name
-
     config_manager.user_config_path = Path(config_file_name)
 
 


### PR DESCRIPTION
Windows doesn't have signals the same way *nix systems do, so asyncio's loop.add_signal_handler isn't implemented in Windows. The main difference between signal.signal and add_signal_handler is that add_signal_handler is asyncio safe, while signal.signal isn't; when the SIG_INT gets caught by signal.signal now, we could be in the middle of an async coroutine and it would be interrupted. I don't think this causes any race conditions; all we do is send an interrupt signal through the sessionstream, but I would like if @waydegg looked over this and gave his thoughts before merging.

Additionally, the reason this wasn't caught by testing is because we weren't running any TerminalClient tests on Windows (due to an issue I discovered a while ago involving PromptToolkit and Github Actions Windows runners specifically); before we get this merged, I'm going to look into resolving that problem in a different way so that we can still run these tests on Windows.