### PR TITLE
Empty string handling

### DIFF
--- a/mentat/code_context.py
+++ b/mentat/code_context.py
@@ -274,7 +274,7 @@ class CodeContext:
         if self.settings.auto_tokens is not None:
             max_sim_tokens = min(max_sim_tokens, self.settings.auto_tokens)
 
-        if self.settings.use_embedding and max_sim_tokens > 0:
+        if self.settings.use_embedding and max_sim_tokens > 0 and prompt != "":
             sim_tokens = 0
 
             # Get embedding-similarity scores for all files

--- a/mentat/terminal/client.py
+++ b/mentat/terminal/client.py
@@ -64,15 +64,17 @@ class TerminalClient:
         assert isinstance(self.session, Session), "TerminalClient is not running"
         while True:
             input_request_message = await self.session.stream.recv("input_request")
-            # TODO: Make extra kwargs like plain constants
-            if (
-                input_request_message.extra is not None
-                and input_request_message.extra.get("plain")
-            ):
-                prompt_session = self._plain_session
-            else:
-                prompt_session = self._prompt_session
-            user_input = await prompt_session.prompt_async(handle_sigint=False)
+            user_input = None
+            while user_input is None or user_input == "":
+                # TODO: Make extra kwargs like plain constants
+                if (
+                    input_request_message.extra is not None
+                    and input_request_message.extra.get("plain")
+                ):
+                    prompt_session = self._plain_session
+                else:
+                    prompt_session = self._prompt_session
+                user_input = await prompt_session.prompt_async(handle_sigint=False)
             assert isinstance(user_input, str)
             if user_input == "q":
                 self._should_exit = True


### PR DESCRIPTION
Currently if you start mentat with no files or give it an empty prompt mentat crashes when it tries to embed an empty string. After fixing that I also made the terminal client not call gpt on empty prompts to prevent expensive errors.