### PR TITLE
Unified diff tweaking

### DIFF
--- a/mentat/parsers/diff_utils.py
+++ b/mentat/parsers/diff_utils.py
@@ -14,7 +14,7 @@ def matching_index(orig_lines: list[str], new_lines: list[str]) -> int:
                 new_orig_lines = [s for s in orig_lines if s]
                 new_new_lines = [s for s in new_lines if s]
                 index = _exact_match(new_orig_lines, new_new_lines)
-                if index != -1:
+                if new_orig_lines and index != -1:
                     index = orig_lines.index(new_orig_lines[index])
     return index
 

--- a/mentat/resources/prompts/unified_diff_parser_prompt.txt
+++ b/mentat/resources/prompts/unified_diff_parser_prompt.txt
@@ -10,25 +10,23 @@ This means that you will be editing old_file_name in the next section of the edi
 Just like a git diff, to rename a file, put a different name in the +++ section from the --- section; to create a file, put --- /dev/null; and to delete a file, put +++ /dev/null.
 Unlike a git diff, when deleting a file, there is no need to print the removed lines.
 The second part of the edit format is the git diff part. In this part, you will print a git diff with context lines prefixed with a space, deleted lines prefixed with a -, and added lines prefixed with a +.
-To mark a new diff for a separate section of code, provide an @@ marker. Finally, end the diff with a @@end marker, like this:
+To mark a new diff for a separate section of code, provide an @@ @@ marker. Finally, end the diff with a @@ end @@ marker, like this:
 --- example.py
 +++ example.py
+@@ @@
  for i in range(10):
 -    print(i)
 +    print(f"Number: {i}")
  return
-@@
+@@ @@
 -print("Hello, World!")
 +print("Goodbye, World!")
-@@end
+@@ end @@
 
 IMPORTANT:
 Unless the file is empty, you *MUST* give context to additions to the file!!! If you do not give context, your lines will be inserted at the very beginning of the file! *THIS INCLUDES IMPORTS!*
 There is no need to print more context lines than are necessary to find the location of the diff within the given file.
-You must *ALWAYS*, *NO MATTER WHAT*, close out a change with a @@end symbol, *EVEN IF* it is just a deletion, creation, or rename.
-NEVER ALTER THE CONTEXT LINES! If you need to change a line, REMOVE IT and REPLACE IT with an added line!
-The context lines MUST MATCH the lines in the file, or your change WILL NOT BE ACCEPTED!
-NEVER OMIT ANY WHITESPACE IN THE CONTEXT LINES!
+The context lines *MUST MATCH* the lines in the file, or your change WILL *NOT BE ACCEPTED*!
 
 
 To demonstrate the response format, here's an example user request, followed by an example response:
@@ -73,21 +71,23 @@ Steps:
 
 --- core/hello_world.py
 +++ core/goodbye_world.py
+@@ @@
 -def hello_world():
 -    print("Hello, World!")
 +def goodbye_world():
 +    print("Goodbye, World!")
-@@
+@@ @@
  def main(name):
 -    hello_world()
 +    goodbye_world()
      print(f"Hello, {name}!")
 +    print(f"Goodbye, {name}!")
-@@end
+@@ end @@
 --- /dev/null
 +++ test.py
+@@ @@
 +print("testing...")
-@@end
+@@ end @@
 --- test.py
 +++ /dev/null
-@@end
+@@ end @@

--- a/tests/parser_tests/unified_diff_format_error_test.py
+++ b/tests/parser_tests/unified_diff_format_error_test.py
@@ -36,6 +36,7 @@ async def test_not_matching(
 
         --- {temp_file_name}
         +++ {temp_file_name}
+        @@ @@
          # Not matching
         -# a temporary file
         -# with
@@ -79,6 +80,7 @@ async def test_no_prefix(
 
         --- {temp_file_name}
         +++ {temp_file_name}
+        @@ @@
         # This is
         -# a temporary file
         -# with

--- a/tests/parser_tests/unified_diff_format_test.py
+++ b/tests/parser_tests/unified_diff_format_test.py
@@ -36,12 +36,13 @@ async def test_replacement(
 
         --- {temp_file_name}
         +++ {temp_file_name}
+        @@ @@
          # This is
         -# a temporary file
         -# with
         +# your captain speaking
          # 4 lines
-        @@end""")])
+        @@ end @@""")])
 
     session = await Session.create([temp_file_name])
     await session.start()
@@ -83,6 +84,7 @@ async def test_multiple_replacements(
 
         --- {temp_file_name}
         +++ {temp_file_name}
+        @@ @@
          # This
         -# is
         +# was
@@ -94,7 +96,7 @@ async def test_multiple_replacements(
         -# 8
         +# new line
          # lines
-        @@end""")])
+        @@ end @@""")])
 
     session = await Session.create([temp_file_name])
     await session.start()
@@ -141,13 +143,14 @@ async def test_multiple_replacement_spots(
 
         --- {temp_file_name}
         +++ {temp_file_name}
+        @@ @@
         -# is
         +# was
-        @@
+        @@ @@
         -# file
          # with
         +# more than
-        @@end""")])
+        @@ end @@""")])
 
     session = await Session.create([temp_file_name])
     await session.start()
@@ -194,12 +197,13 @@ async def test_little_context_addition(
 
         --- {temp_file_name}
         +++ {temp_file_name}
+        @@ @@
          # is
         +# New line
-        @@
+        @@ @@
         +# New line 2
          # with 
-        @@end""")])
+        @@ end @@""")])
 
     session = await Session.create([temp_file_name])
     await session.start()
@@ -240,9 +244,10 @@ async def test_empty_file(
 
         --- {temp_file_name}
         +++ {temp_file_name}
+        @@ @@
         +# New
         +# line
-        @@end""")])
+        @@ end @@""")])
 
     session = await Session.create([temp_file_name])
     await session.start()
@@ -272,8 +277,9 @@ async def test_creation(mock_call_llm_api, mock_collect_user_input, mock_setup_a
 
         --- /dev/null
         +++ {temp_file_name}
+        @@ @@
         +# New line
-        @@end
+        @@ end @@
         """)])
 
     session = await Session.create([temp_file_name])
@@ -313,7 +319,7 @@ async def test_deletion(mock_call_llm_api, mock_collect_user_input, mock_setup_a
 
         --- {temp_file_name}
         +++ /dev/null
-        @@end""")])
+        @@ end @@""")])
 
     session = await Session.create([temp_file_name])
     await session.start()
@@ -345,6 +351,7 @@ async def test_no_ending_marker(
 
         --- {temp_file_name}
         +++ {temp_file_name}
+        @@ @@
          # This is
         -# a temporary file
         -# with


### PR DESCRIPTION
Fix unified diff bugs; tweak prompt a bit to be slightly more similar to the git diff format. Things I still haven't tried yet:

Adding a/ and b/ to filenames (like a git diff would have)
Having diff --git file_name_1 file_name_2 line at start

Working on seeing if adding those has any significant effect (although I doubt it will)