### PR TITLE
Backoff llm api calls

### DIFF
--- a/mentat/broadcast.py
+++ b/mentat/broadcast.py
@@ -60,6 +60,13 @@ class MemoryBackend:
         else:
             self._missed_events[channel].append(event)
 
+    def publish_sync(self, channel: str, message: Any) -> None:
+        event = Event(channel=channel, message=message)
+        if channel in self._subscribed:
+            self._published.put_nowait(event)
+        else:
+            self._missed_events[channel].append(event)
+
     async def next_published(self) -> Event:
         while True:
             return await self._published.get()
@@ -100,6 +107,9 @@ class Broadcast:
 
     async def publish(self, channel: str, message: Any) -> None:
         await self._backend.publish(channel, message)
+
+    def publish_sync(self, channel: str, message: Any) -> None:
+        self._backend.publish_sync(channel, message)
 
     @asynccontextmanager
     async def subscribe(self, channel: str) -> AsyncIterator[Subscriber]:

--- a/mentat/conversation.py
+++ b/mentat/conversation.py
@@ -6,7 +6,7 @@ from contextvars import ContextVar
 from enum import Enum
 from timeit import default_timer
 
-from openai.error import InvalidRequestError, RateLimitError
+from openai.error import InvalidRequestError
 
 from mentat.parsers.file_edit import FileEdit
 from mentat.parsers.parser import PARSER, Parser
@@ -14,7 +14,7 @@ from tests.conftest import SessionStream
 
 from .code_context import CODE_CONTEXT
 from .config_manager import CONFIG_MANAGER, user_config_path
-from .errors import MentatError, UserError
+from .errors import MentatError
 from .llm_api import (
     COST_TRACKER,
     call_llm_api,
@@ -154,8 +154,6 @@ class Conversation:
                 " returned:\n"
                 + str(e)
             )
-        except RateLimitError as e:
-            raise UserError("OpenAI gave a rate limit error:\n" + str(e))
 
         time_elapsed = default_timer() - start_time
         return (parsedLLMResponse, time_elapsed)

--- a/mentat/llm_api.py
+++ b/mentat/llm_api.py
@@ -5,12 +5,14 @@ import os
 import sys
 from contextvars import ContextVar
 from dataclasses import dataclass
+from functools import partial
 from typing import Any, AsyncGenerator, Optional, cast
 
 import backoff
 import openai
 import openai.error
 import tiktoken
+from backoff.types import Details
 from dotenv import load_dotenv
 from openai.error import AuthenticationError, RateLimitError, Timeout
 
@@ -73,14 +75,23 @@ def raise_if_in_test_environment():
         raise MentatError("OpenAI call attempted in non benchmark test environment!")
 
 
+async def warn_user(message: str, max_tries: int, details: Details):
+    stream = SESSION_STREAM.get()
+
+    warning = f"{message}: Retry number {details['tries']}/{max_tries - 1}..."
+    await stream.send(warning, color="light_yellow")
+
+
 @backoff.on_exception(
     wait_gen=backoff.expo,
     exception=Timeout,
     max_tries=5,
     base=2,
     factor=2,
+    jitter=None,
     logger="",
     giveup_log_level=logging.INFO,
+    on_backoff=partial(warn_user, "Error reaching OpenAI's servers", 5),
 )
 @backoff.on_exception(
     wait_gen=backoff.expo,
@@ -88,8 +99,10 @@ def raise_if_in_test_environment():
     max_tries=3,
     base=2,
     factor=10,
+    jitter=None,
     logger="",
     giveup_log_level=logging.INFO,
+    on_backoff=partial(warn_user, "Rate limit recieved from OpenAI's servers", 3),
 )
 async def call_llm_api(
     messages: list[dict[str, str]], model: str

--- a/mentat/llm_api.py
+++ b/mentat/llm_api.py
@@ -74,10 +74,22 @@ def raise_if_in_test_environment():
 
 
 @backoff.on_exception(
-    wait_gen=backoff.expo, exception=Timeout, max_tries=5, base=2, factor=2
+    wait_gen=backoff.expo,
+    exception=Timeout,
+    max_tries=5,
+    base=2,
+    factor=2,
+    logger="",
+    giveup_log_level=logging.INFO,
 )
 @backoff.on_exception(
-    wait_gen=backoff.expo, exception=RateLimitError, max_tries=3, base=2, factor=10
+    wait_gen=backoff.expo,
+    exception=RateLimitError,
+    max_tries=3,
+    base=2,
+    factor=10,
+    logger="",
+    giveup_log_level=logging.INFO,
 )
 async def call_llm_api(
     messages: list[dict[str, str]], model: str

--- a/mentat/llm_api.py
+++ b/mentat/llm_api.py
@@ -82,11 +82,15 @@ async def warn_user(message: str, max_tries: int, details: Details):
     await stream.send(warning, color="light_yellow")
 
 
+# This can be mocked in benchmarks to increase the wait time
+backoff_delay_base = 2
+
+
 @backoff.on_exception(
     wait_gen=backoff.expo,
     exception=Timeout,
     max_tries=5,
-    base=2,
+    base=backoff_delay_base,
     factor=2,
     jitter=None,
     logger="",
@@ -97,7 +101,7 @@ async def warn_user(message: str, max_tries: int, details: Details):
     wait_gen=backoff.expo,
     exception=RateLimitError,
     max_tries=3,
-    base=2,
+    base=backoff_delay_base,
     factor=10,
     jitter=None,
     logger="",

--- a/mentat/parsers/file_edit.py
+++ b/mentat/parsers/file_edit.py
@@ -74,18 +74,21 @@ class FileEdit:
         if self.is_creation:
             if self.file_path.exists():
                 await stream.send(
-                    f"File {rel_path} already exists, canceling creation."
+                    f"File {rel_path} already exists, canceling creation.",
+                    color="light_yellow",
                 )
                 return False
         else:
             if not self.file_path.exists():
                 await stream.send(
-                    f"File {rel_path} does not exist, canceling all edits to file."
+                    f"File {rel_path} does not exist, canceling all edits to file.",
+                    color="light_yellow",
                 )
                 return False
             elif rel_path not in code_file_manager.file_lines:
                 await stream.send(
-                    f"File {rel_path} not in context, canceling all edits to file."
+                    f"File {rel_path} not in context, canceling all edits to file.",
+                    color="light_yellow",
                 )
                 return False
 
@@ -93,7 +96,8 @@ class FileEdit:
             rel_rename_path = Path(os.path.relpath(self.rename_file_path, git_root))
             await stream.send(
                 f"File {rel_path} being renamed to existing file {rel_rename_path},"
-                " canceling rename."
+                " canceling rename.",
+                color="light_yellow",
             )
             self.rename_file_path = None
         return True

--- a/mentat/session.py
+++ b/mentat/session.py
@@ -125,10 +125,13 @@ class Session:
                     need_user_request = await get_user_feedback_on_edits(file_edits)
                 else:
                     need_user_request = True
+                await stream.send(bool(file_edits), channel="edits_complete")
         except SessionExit:
             pass
         except (Timeout, RateLimitError) as e:
             await stream.send(f"Error accessing OpenAI API: {str(e)}", color="red")
+        finally:
+            await stream.send(None, channel="exit")
 
     ### lifecycle
 

--- a/mentat/session.py
+++ b/mentat/session.py
@@ -5,6 +5,8 @@ from pathlib import Path
 from typing import List, Optional, Union, cast
 from uuid import uuid4
 
+from openai.error import RateLimitError, Timeout
+
 from mentat.logging_config import setup_logging
 
 from .code_context import CODE_CONTEXT, CodeContext, CodeContextSettings
@@ -125,6 +127,8 @@ class Session:
                     need_user_request = True
         except SessionExit:
             pass
+        except (Timeout, RateLimitError) as e:
+            await stream.send(f"Error accessing OpenAI API: {str(e)}", color="red")
 
     ### lifecycle
 

--- a/mentat/session_stream.py
+++ b/mentat/session_stream.py
@@ -69,6 +69,27 @@ class SessionStream:
 
         return message
 
+    def send_sync(
+        self,
+        data: Any,
+        source: StreamMessageSource = StreamMessageSource.SERVER,
+        channel: str = "default",
+        **kwargs: Any,
+    ):
+        message = StreamMessage(
+            id=uuid4(),
+            source=source,
+            channel=channel,
+            data=data,
+            created_at=datetime.utcnow(),
+            extra=kwargs,
+        )
+
+        self.messages.append(message)
+        self._broadcast.publish_sync(channel=channel, message=message)
+
+        return message
+
     async def recv(self, channel: str = "default") -> StreamMessage:
         """Listen for a single event on a channel"""
         async with self._broadcast.subscribe(channel) as subscriber:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
+backoff==2.2.1
 fire==0.5.0
 numpy==1.26.0
 openai==0.27.8

--- a/tests/benchmarks/exercism_practice.py
+++ b/tests/benchmarks/exercism_practice.py
@@ -125,6 +125,7 @@ async def run_exercise(problem_dir, language="python", max_iterations=2):
         exclude_paths=exercise_runner.exclude_files(),
         no_code_map=True,
     )
+    await client.startup()
 
     prompt_1 = (
         f"Use the instructions in {exercise_runner.docs()} to modify"
@@ -138,7 +139,7 @@ async def run_exercise(problem_dir, language="python", max_iterations=2):
     )
 
     iterations = 0
-    while iterations < max_iterations:
+    while iterations < max_iterations and client.started:
         if exercise_runner.passed():
             break
         message = (

--- a/tests/benchmarks/exercism_practice.py
+++ b/tests/benchmarks/exercism_practice.py
@@ -148,10 +148,12 @@ async def run_exercise(problem_dir, language="python", max_iterations=2):
             else exercise_runner.get_error_message() + prompt_2
         )
         await client.call_mentat_auto_accept(message)
+        await client.wait_for_edit_completion()
 
         exercise_runner.run_test()
         iterations += 1
 
+    had_error = not client.started
     await client.stop()
     passed = exercise_runner.passed()
     result = {
@@ -159,7 +161,10 @@ async def run_exercise(problem_dir, language="python", max_iterations=2):
         "passed": passed,
         "test": exercise_runner.name,
     }
-    if not result["passed"]:
+    if had_error:
+        result["response"] = "Error while running mentat"
+        result["reason"] = "error"
+    elif not result["passed"]:
         response, reason = await failure_analysis(exercise_runner, language)
         result["response"] = response
         result["reason"] = reason

--- a/tests/clients/python_client_test.py
+++ b/tests/clients/python_client_test.py
@@ -26,7 +26,9 @@ async def test_editing_file_auto_accept(mock_call_llm_api, mock_setup_api_key):
         @@end""")])
 
     python_client = PythonClient(["."])
+    await python_client.startup()
     await python_client.call_mentat_auto_accept("Conversation")
+    await python_client.wait_for_edit_completion()
     with open(file_name, "r") as f:
         content = f.read()
         expected_content = "# Line 1\n# Line 2"
@@ -55,7 +57,9 @@ async def test_collects_mentat_response(mock_call_llm_api, mock_setup_api_key):
         @@end""")])
 
     python_client = PythonClient(["."])
+    await python_client.startup()
     response = await python_client.call_mentat("Conversation")
+    response += await python_client.call_mentat("y")
     assert "Conversation" in response
     assert "Apply these changes? 'Y/n/i' or provide feedback." in response
     await python_client.stop()


### PR DESCRIPTION
Add backoff to llm api calls and stop errors from bricking benchmarks. @jakethekoenig I don't really like the way I had to set up the python client to detect when the session is stopped, but because of the way we run the benchmarks (where we wait for the next input request to confirm that all changes have been made) I'm not sure of a better way to do it. Maybe in the future we should have the server send a message confirming that changes have been written? This could be useful for the vscode extension too.