### PR TITLE
Default to auto-token limit of 0

### DIFF
--- a/mentat/code_context.py
+++ b/mentat/code_context.py
@@ -112,13 +112,15 @@ class CodeContext:
             )
         else:
             await stream.send(f"{prefix}Included files: None", color="yellow")
-        await stream.send(
-            f"{prefix}CodeMaps: {'Enabled' if self.code_map else 'Disabled'}"
-        )
         auto = self.settings.auto_tokens
         await stream.send(
-            f"{prefix}Auto-tokens: {'Model max (default)' if auto is None else auto}"
+            f"{prefix}Auto-token limit:"
+            f" {'Model max (default)' if auto is None else auto}"
         )
+        if auto != 0:
+            await stream.send(
+                f"{prefix}CodeMaps: {'Enabled' if self.code_map else 'Disabled'}"
+            )
 
     async def display_features(self):
         """Display a summary of all active features"""

--- a/mentat/terminal/client.py
+++ b/mentat/terminal/client.py
@@ -237,7 +237,7 @@ def run_cli():
         "--auto-tokens",
         "-a",
         type=int,
-        default=None,
+        default=0,
         help="Maximum number of auto-generated tokens to include in the prompt context",
     )
     args = parser.parse_args()


### PR DESCRIPTION
- changes default auto-token limit to 0 (instead of model max)
- doesn't print "CodeMaps: Enabled/Disabled" if the auto-token limit is 0 (since they won't be included either way)

Before making a non-zero default again we need to make it clearer to users what costs will be and make sure the extra context helps enough