### PR TITLE
switch to use abs-paths for parsers renames

### DIFF
--- a/mentat/parsers/block_parser.py
+++ b/mentat/parsers/block_parser.py
@@ -171,7 +171,9 @@ class BlockParser(Parser):
             replacements,
             is_creation=file_action == FileActionType.CreateFile,
             is_deletion=file_action == FileActionType.DeleteFile,
-            rename_file_path=deserialized_json.name,
+            rename_file_path=(
+                git_root / deserialized_json.name if deserialized_json.name else None
+            ),
         )
         has_code = block[-1] == _BlockParserIndicator.Code.value
         return (display_information, file_edit, has_code)
@@ -223,7 +225,7 @@ class BlockParser(Parser):
                     _BlockParserAction.RenameFile.value
                 )
                 tmp[_BlockParserJsonKeys.Name.value] = (
-                    file_edit.rename_file_path.as_posix()
+                    file_edit.rename_file_path.relative_to(git_root).as_posix()
                 )
             if _BlockParserJsonKeys.Action.value in tmp:
                 ans += _BlockParserIndicator.Start.value + "\n"

--- a/mentat/parsers/replacement_parser.py
+++ b/mentat/parsers/replacement_parser.py
@@ -93,7 +93,7 @@ class ReplacementParser(Parser):
             [],
             is_creation=file_action_type == FileActionType.CreateFile,
             is_deletion=file_action_type == FileActionType.DeleteFile,
-            rename_file_path=new_name,
+            rename_file_path=git_root / new_name if new_name else None,
         )
         has_code = file_action_type == FileActionType.UpdateFile
         return (display_information, file_edit, has_code)
@@ -134,7 +134,9 @@ class ReplacementParser(Parser):
             elif file_edit.is_deletion:
                 action_indicator = "-"
             elif file_edit.rename_file_path is not None:
-                action_indicator = file_edit.rename_file_path.as_posix()
+                action_indicator = file_edit.rename_file_path.relative_to(
+                    git_root
+                ).as_posix()
 
             file_rel_path = file_edit.file_path.relative_to(git_root).as_posix()
             if action_indicator != "":

--- a/mentat/parsers/split_diff_parser.py
+++ b/mentat/parsers/split_diff_parser.py
@@ -111,7 +111,11 @@ class SplitDiffParser(Parser):
             new_name=new_name,
         )
         file_edit = FileEdit(
-            git_root / file_name, [], is_creation, is_deletion, new_name
+            git_root / file_name,
+            [],
+            is_creation,
+            is_deletion,
+            git_root / new_name if new_name else None,
         )
         return (
             display_information,

--- a/mentat/parsers/unified_diff_parser.py
+++ b/mentat/parsers/unified_diff_parser.py
@@ -108,7 +108,11 @@ class UnifiedDiffParser(Parser):
             file_name, file_lines, [], [], file_action_type, -1, -1, new_name
         )
         file_edit = FileEdit(
-            git_root / file_name, [], is_creation, is_deletion, new_name
+            git_root / file_name,
+            [],
+            is_creation,
+            is_deletion,
+            git_root / new_name if new_name else None,
         )
         return (
             display_information,

--- a/tests/parser_tests/inverse.py
+++ b/tests/parser_tests/inverse.py
@@ -70,7 +70,7 @@ async def verify_inverse(parser):
                 ],
                 is_creation=False,
                 is_deletion=False,
-                rename_file_path=Path("file2.txt"),
+                rename_file_path=Path("file2.txt").resolve(),
             ),
         ],
     )

--- a/tests/parser_tests/inverse.py
+++ b/tests/parser_tests/inverse.py
@@ -17,7 +17,7 @@ async def verify_inverse(parser):
         """),
         file_edits=[
             FileEdit(
-                file_path=Path(cwd / "test.txt"),
+                file_path=cwd / "test.txt",
                 replacements=[
                     Replacement(
                         starting_line=1,
@@ -33,7 +33,7 @@ async def verify_inverse(parser):
                 rename_file_path=None,
             ),
             FileEdit(
-                file_path=Path(cwd / "delete.txt"),
+                file_path=cwd / "delete.txt",
                 replacements=[
                     Replacement(starting_line=1, ending_line=3, new_lines=[])
                 ],
@@ -42,7 +42,7 @@ async def verify_inverse(parser):
                 rename_file_path=None,
             ),
             FileEdit(
-                file_path=Path(cwd / "create.txt"),
+                file_path=cwd / "create.txt",
                 replacements=[
                     Replacement(
                         starting_line=0,
@@ -55,7 +55,7 @@ async def verify_inverse(parser):
                 rename_file_path=None,
             ),
             FileEdit(
-                file_path=Path(cwd / "file1.txt"),
+                file_path=cwd / "file1.txt",
                 replacements=[
                     Replacement(
                         starting_line=1,
@@ -70,7 +70,7 @@ async def verify_inverse(parser):
                 ],
                 is_creation=False,
                 is_deletion=False,
-                rename_file_path=Path("file2.txt").resolve(),
+                rename_file_path=cwd / "file2.txt",
             ),
         ],
     )


### PR DESCRIPTION
Fixes #181. I meant for this to be the default when I designed the FileEdit and Parser classes, but clearly I forgot about it along the way.