### PR TITLE
fix context checking in fileedit, remove test.conftest imports

### DIFF
--- a/mentat/parsers/file_edit.py
+++ b/mentat/parsers/file_edit.py
@@ -66,8 +66,12 @@ class FileEdit:
     rename_file_path: Path | None = attr.field(default=None)
 
     async def is_valid(self) -> bool:
+        # TODO: Remove this when we create SessionContext
+        # This fixes a circular import
+        from mentat.code_context import CODE_CONTEXT
+
         stream = SESSION_STREAM.get()
-        code_file_manager = CODE_FILE_MANAGER.get()
+        code_context = CODE_CONTEXT.get()
         git_root = GIT_ROOT.get()
 
         rel_path = Path(os.path.relpath(self.file_path, git_root))
@@ -83,7 +87,7 @@ class FileEdit:
                     f"File {rel_path} does not exist, canceling all edits to file."
                 )
                 return False
-            elif rel_path not in code_file_manager.file_lines:
+            elif self.file_path not in code_context.include_files:
                 await stream.send(
                     f"File {rel_path} not in context, canceling all edits to file."
                 )

--- a/mentat/session_input.py
+++ b/mentat/session_input.py
@@ -22,6 +22,7 @@ async def collect_user_input(plain: bool = False) -> StreamMessage:
     create a new broadcast channel that listens for the input
     close the channel after receiving the input
     """
+    # TODO: Remove this when we create SessionContext
     # This fixes a circular import
     from mentat.commands import Command
 

--- a/tests/parser_tests/block_format_error_test.py
+++ b/tests/parser_tests/block_format_error_test.py
@@ -2,8 +2,8 @@ from textwrap import dedent
 
 import pytest
 
+from mentat.config_manager import ConfigManager
 from mentat.session import Session
-from tests.conftest import ConfigManager
 
 
 @pytest.fixture(autouse=True)

--- a/tests/parser_tests/block_format_test.py
+++ b/tests/parser_tests/block_format_test.py
@@ -3,9 +3,9 @@ from textwrap import dedent
 
 import pytest
 
+from mentat.config_manager import ConfigManager
 from mentat.parsers.block_parser import BlockParser
 from mentat.session import Session
-from tests.conftest import ConfigManager
 from tests.parser_tests.inverse import verify_inverse
 
 

--- a/tests/parser_tests/replacement_format_error_test.py
+++ b/tests/parser_tests/replacement_format_error_test.py
@@ -2,8 +2,8 @@ from textwrap import dedent
 
 import pytest
 
+from mentat.config_manager import ConfigManager
 from mentat.session import Session
-from tests.conftest import ConfigManager
 
 
 @pytest.fixture(autouse=True)

--- a/tests/parser_tests/replacement_format_test.py
+++ b/tests/parser_tests/replacement_format_test.py
@@ -3,9 +3,9 @@ from textwrap import dedent
 
 import pytest
 
+from mentat.config_manager import ConfigManager
 from mentat.parsers.replacement_parser import ReplacementParser
 from mentat.session import Session
-from tests.conftest import ConfigManager
 from tests.parser_tests.inverse import verify_inverse
 
 

--- a/tests/parser_tests/split_diff_format_test.py
+++ b/tests/parser_tests/split_diff_format_test.py
@@ -1,8 +1,10 @@
 from pathlib import Path
 from textwrap import dedent
 
+import pytest
+
+from mentat.config_manager import ConfigManager
 from mentat.session import Session
-from tests.conftest import ConfigManager, pytest
 
 
 @pytest.fixture(autouse=True)

--- a/tests/parser_tests/unified_diff_format_test.py
+++ b/tests/parser_tests/unified_diff_format_test.py
@@ -1,8 +1,10 @@
 from pathlib import Path
 from textwrap import dedent
 
+import pytest
+
+from mentat.config_manager import ConfigManager
 from mentat.session import Session
-from tests.conftest import ConfigManager, pytest
 
 
 @pytest.fixture(autouse=True)


### PR DESCRIPTION
Fixes #173. I'm going to work on adding SessionContext after this, since it clearly would help with circular imports quite a bit