### PR TITLE
Create file not in context

### DIFF
--- a/mentat/code_file_manager.py
+++ b/mentat/code_file_manager.py
@@ -45,11 +45,11 @@ class CodeFileManager:
 
     def _create_file(self, code_context: CodeContext, abs_path: Path):
         logging.info(f"Creating new file {abs_path}")
-        code_context.include_file(abs_path)
         # Create any missing directories in the path
         abs_path.parent.mkdir(parents=True, exist_ok=True)
         with open(abs_path, "w") as f:
             f.write("")
+        code_context.include_file(abs_path)
 
     def _delete_file(self, code_context: CodeContext, abs_path: Path):
         logging.info(f"Deleting file {abs_path}")

--- a/tests/code_file_manager_test.py
+++ b/tests/code_file_manager_test.py
@@ -121,6 +121,48 @@ async def test_run_from_subdirectory(
 
 
 @pytest.mark.asyncio
+async def test_change_after_creation(
+    mock_collect_user_input, mock_call_llm_api, mock_setup_api_key
+):
+    file_name = Path("hello_world.py")
+    mock_collect_user_input.set_stream_messages(
+        [
+            "Conversation",
+            "y",
+            "q",
+        ]
+    )
+    mock_call_llm_api.set_generator_values([dedent(f"""\
+        Conversation
+
+        @@start
+        {{
+            "file": "{file_name}",
+            "action": "create-file"
+        }}
+        @@code
+        @@end
+        @@start
+        {{
+            "file": "{file_name}",
+            "action": "insert",
+            "insert-after-line": 0,
+            "insert-before-line": 1
+        }}
+        @@code
+        print("Hello, World!")
+        @@end""")])
+
+    session = await Session.create()
+    await session.start()
+    await session.stream.stop()
+
+    with file_name.open() as f:
+        output = f.read()
+    assert output == 'print("Hello, World!")'
+
+
+@pytest.mark.asyncio
 async def test_changed_file(
     mocker,
     temp_testbed,


### PR DESCRIPTION
Fixes #188. Since we don't add files that don't exist to context, we need to create the file before we include it.