### PR TITLE
fix abs path auto completions

### DIFF
--- a/mentat/terminal/prompt_completer.py
+++ b/mentat/terminal/prompt_completer.py
@@ -16,6 +16,7 @@ from pygments.util import ClassNotFound
 
 from mentat.code_context import CODE_CONTEXT
 from mentat.commands import Command
+from mentat.git_handler import GIT_ROOT
 
 
 @dataclass
@@ -66,8 +67,11 @@ class MentatCompleter(Completer):
 
     async def refresh_completions(self):
         code_context = CODE_CONTEXT.get()
+        git_root = GIT_ROOT.get()
 
-        file_paths = list(code_context.include_files.keys())
+        file_paths = [
+            path.relative_to(git_root) for path in code_context.include_files.keys()
+        ]
 
         # Remove syntax completions for files not in the context
         for file_path in set(self.syntax_completions.keys()):


### PR DESCRIPTION
Fixes #191. We still suggest paths relative to the git root (rather than just the file_name) because that path is what the model sees and outputs and will most likely be the best one to use in the prompt.