### PR TITLE
update diff_context and tests to use absolute path

### DIFF
--- a/mentat/diff_context.py
+++ b/mentat/diff_context.py
@@ -105,10 +105,10 @@ class DiffContext:
     @property
     def files(self) -> list[Path]:
         if self._files_cache is None:
+            git_root = GIT_ROOT.get()
             if self.target == "HEAD" and not check_head_exists():
                 return []  # A new repo without any commits
-            diff_files = get_files_in_diff(self.target)
-            self._files_cache = [f.resolve() for f in diff_files]
+            self._files_cache = [git_root / f for f in get_files_in_diff(self.target)]
         return self._files_cache
 
     @classmethod

--- a/mentat/diff_context.py
+++ b/mentat/diff_context.py
@@ -107,7 +107,8 @@ class DiffContext:
         if self._files_cache is None:
             if self.target == "HEAD" and not check_head_exists():
                 return []  # A new repo without any commits
-            self._files_cache = get_files_in_diff(self.target)
+            diff_files = get_files_in_diff(self.target)
+            self._files_cache = [f.resolve() for f in diff_files]
         return self._files_cache
 
     @classmethod

--- a/tests/diff_context_test.py
+++ b/tests/diff_context_test.py
@@ -1,4 +1,3 @@
-import os
 import subprocess
 from pathlib import Path
 

--- a/tests/diff_context_test.py
+++ b/tests/diff_context_test.py
@@ -6,9 +6,11 @@ import pytest
 
 from mentat.diff_context import DiffContext
 
+
 @pytest.fixture
 def abs_path(temp_testbed):
     return Path(temp_testbed).resolve() / "multifile_calculator/operations.py"
+
 
 def _update_ops(temp_testbed, last_line, commit_message=None):
     # Update the last line of operations.py and (optionally) commit

--- a/tests/diff_context_test.py
+++ b/tests/diff_context_test.py
@@ -7,14 +7,10 @@ import pytest
 from mentat.diff_context import DiffContext
 
 
-@pytest.fixture
-def abs_path(temp_testbed):
-    return Path(temp_testbed).resolve() / "multifile_calculator/operations.py"
-
-
 def _update_ops(temp_testbed, last_line, commit_message=None):
     # Update the last line of operations.py and (optionally) commit
-    abs_path = os.path.join(temp_testbed, "multifile_calculator", "operations.py")
+    abs_path = Path(temp_testbed) / "multifile_calculator" / "operations.py"
+
     with open(abs_path, "r") as f:
         lines = f.readlines()
     lines[-1:] = [
@@ -57,8 +53,10 @@ def _get_file_message(abs_path):
 
 
 def test_diff_context_default(
-    mock_stream, mock_config, temp_testbed, git_history, mock_git_root, abs_path
+    mock_stream, mock_config, temp_testbed, git_history, mock_git_root
 ):
+    abs_path = Path(temp_testbed) / "multifile_calculator" / "operations.py"
+
     # DiffContext.__init__() (default): active code vs last commit
     diff_context = DiffContext()
     assert diff_context.target == "HEAD"
@@ -82,8 +80,10 @@ def test_diff_context_default(
 
 @pytest.mark.asyncio
 async def test_diff_context_commit(
-    mock_stream, mock_config, temp_testbed, git_history, mock_git_root, abs_path
+    mock_stream, mock_config, temp_testbed, git_history, mock_git_root
 ):
+    abs_path = Path(temp_testbed) / "multifile_calculator" / "operations.py"
+
     # Get the hash of 2-commits-ago
     last_commit = subprocess.check_output(
         ["git", "rev-parse", "HEAD~2"], cwd=temp_testbed, text=True
@@ -104,8 +104,10 @@ async def test_diff_context_commit(
 
 @pytest.mark.asyncio
 async def test_diff_context_branch(
-    mock_stream, mock_config, temp_testbed, git_history, mock_git_root, abs_path
+    mock_stream, mock_config, temp_testbed, git_history, mock_git_root
 ):
+    abs_path = Path(temp_testbed) / "multifile_calculator" / "operations.py"
+
     diff_context = await DiffContext.create(diff="test_branch")
     assert diff_context.target == "test_branch"
     assert diff_context.name.startswith("Branch test_branch:")
@@ -123,8 +125,10 @@ async def test_diff_context_branch(
 
 @pytest.mark.asyncio
 async def test_diff_context_relative(
-    mock_stream, mock_config, temp_testbed, git_history, mock_git_root, abs_path
+    mock_stream, mock_config, temp_testbed, git_history, mock_git_root
 ):
+    abs_path = Path(temp_testbed) / "multifile_calculator" / "operations.py"
+
     diff_context = await DiffContext.create(diff="HEAD~2")
     assert diff_context.target == "HEAD~2"
     assert diff_context.name.startswith("HEAD~2: ")
@@ -142,8 +146,10 @@ async def test_diff_context_relative(
 
 @pytest.mark.asyncio
 async def test_diff_context_pr(
-    mock_stream, mock_config, temp_testbed, git_history, mock_git_root, abs_path
+    mock_stream, mock_config, temp_testbed, git_history, mock_git_root
 ):
+    abs_path = Path(temp_testbed) / "multifile_calculator" / "operations.py"
+
     subprocess.run(["git", "checkout", "test_branch"], cwd=temp_testbed)
     diff_context = await DiffContext.create(pr_diff="master")
 


### PR DESCRIPTION
This addresses an issue in the latest comment in #154. We recently switched from relative to absolute paths in several places, and diff_context was overlooked. 