### PR TITLE
Remove async from send

### DIFF
--- a/mentat/broadcast.py
+++ b/mentat/broadcast.py
@@ -1,10 +1,11 @@
 # Adapted from https://github.com/encode/broadcaster
+from __future__ import annotations
 
 import asyncio
 from asyncio import Queue
 from collections import defaultdict
-from contextlib import asynccontextmanager
-from typing import Any, AsyncGenerator, AsyncIterator, Dict, Set
+from contextlib import contextmanager
+from typing import Any, AsyncGenerator, Dict, Iterator, Set
 
 import attr
 
@@ -38,29 +39,30 @@ class MemoryBackend:
         self._subscribed: Set[str] = set()
         self._missed_events: defaultdict[str, list[Event]] = defaultdict(list)
 
-    async def connect(self) -> None:
+    def connect(self) -> None:
         self._published: Queue[Event] = Queue()
 
-    async def disconnect(self) -> None:
+    def disconnect(self) -> None:
         pass
 
-    async def subscribe(self, channel: str) -> None:
+    def subscribe(self, channel: str) -> None:
         self._subscribed.add(channel)
         for event in self._missed_events[channel]:
-            await self.publish(event.channel, event.message)
+            self.publish(event.channel, event.message)
         self._missed_events[channel].clear()
 
-    async def unsubscribe(self, channel: str) -> None:
+    def unsubscribe(self, channel: str) -> None:
         self._subscribed.remove(channel)
 
-    async def publish(self, channel: str, message: Any) -> None:
+    # Since there is no maximum queue size, use the synchronous version of this function instead
+    async def publish_async(self, channel: str, message: Any) -> None:
         event = Event(channel=channel, message=message)
         if channel in self._subscribed:
             await self._published.put(event)
         else:
             self._missed_events[channel].append(event)
 
-    def publish_sync(self, channel: str, message: Any) -> None:
+    def publish(self, channel: str, message: Any) -> None:
         event = Event(channel=channel, message=message)
         if channel in self._subscribed:
             self._published.put_nowait(event)
@@ -81,43 +83,44 @@ class Broadcast:
         self._subscribers: Dict[str, set[Queue[Event | None]]] = {}
         self._backend = MemoryBackend()
 
-    async def __aenter__(self) -> "Broadcast":
-        await self.connect()
+    def __enter__(self) -> Broadcast:
+        self.connect()
         return self
 
-    async def __aexit__(self, *args: Any, **kwargs: Any) -> None:
-        await self.disconnect()
+    def __exit__(self, *args: Any, **kwargs: Any) -> None:
+        self.disconnect()
 
-    async def connect(self) -> None:
-        await self._backend.connect()
+    def connect(self) -> None:
+        self._backend.connect()
         self._listener_task = asyncio.create_task(self._listener())
 
-    async def disconnect(self) -> None:
+    def disconnect(self) -> None:
         if self._listener_task.done():
             self._listener_task.result()
         else:
             self._listener_task.cancel()
-        await self._backend.disconnect()
+        self._backend.disconnect()
 
     async def _listener(self) -> None:
         while True:
             event = await self._backend.next_published()
             for queue in list(self._subscribers.get(event.channel, set())):
-                await queue.put(event)
+                queue.put_nowait(event)
 
-    async def publish(self, channel: str, message: Any) -> None:
-        await self._backend.publish(channel, message)
+    # Since there is no maximum queue size, use the synchronous version of this function instead
+    async def publish_async(self, channel: str, message: Any) -> None:
+        await self._backend.publish_async(channel, message)
 
-    def publish_sync(self, channel: str, message: Any) -> None:
-        self._backend.publish_sync(channel, message)
+    def publish(self, channel: str, message: Any) -> None:
+        self._backend.publish(channel, message)
 
-    @asynccontextmanager
-    async def subscribe(self, channel: str) -> AsyncIterator[Subscriber]:
+    @contextmanager
+    def subscribe(self, channel: str) -> Iterator[Subscriber]:
         queue: Queue[Event | None] = Queue()
 
         try:
             if not self._subscribers.get(channel):
-                await self._backend.subscribe(channel)
+                self._backend.subscribe(channel)
                 self._subscribers[channel] = set()
 
             self._subscribers[channel].add(queue)
@@ -126,6 +129,6 @@ class Broadcast:
 
             if not self._subscribers.get(channel):
                 del self._subscribers[channel]
-                await self._backend.unsubscribe(channel)
+                self._backend.unsubscribe(channel)
         finally:
-            await queue.put(None)
+            queue.put_nowait(None)

--- a/mentat/code_edit_feedback.py
+++ b/mentat/code_edit_feedback.py
@@ -14,7 +14,7 @@ async def get_user_feedback_on_edits(
     code_file_manager = session_context.code_file_manager
     code_context = session_context.code_context
 
-    await stream.send(
+    stream.send(
         "Apply these changes? 'Y/n/i' or provide feedback.",
         color="light_blue",
     )
@@ -55,16 +55,16 @@ async def get_user_feedback_on_edits(
             )
 
     for file_edit in edits_to_apply:
-        await file_edit.resolve_conflicts()
+        file_edit.resolve_conflicts()
 
     if edits_to_apply:
         await code_file_manager.write_changes_to_files(edits_to_apply, code_context)
-        await stream.send("Changes applied.", color="light_blue")
+        stream.send("Changes applied.", color="light_blue")
     else:
-        await stream.send("No changes applied.", color="light_blue")
+        stream.send("No changes applied.", color="light_blue")
 
     if need_user_request:
-        await stream.send("Can I do anything else for you?", color="light_blue")
+        stream.send("Can I do anything else for you?", color="light_blue")
 
     return need_user_request
 

--- a/mentat/code_file_manager.py
+++ b/mentat/code_file_manager.py
@@ -87,18 +87,16 @@ class CodeFileManager:
                         f"Attempted to edit non-existent file {file_edit.file_path}"
                     )
                 elif file_edit.file_path not in code_context.include_files:
-                    await stream.send(
+                    stream.send(
                         f"Attempted to edit file {file_edit.file_path} not in context",
                         color="yellow",
                     )
                     continue
 
             if file_edit.is_deletion:
-                await stream.send(
-                    f"Are you sure you want to delete {rel_path}?", color="red"
-                )
+                stream.send(f"Are you sure you want to delete {rel_path}?", color="red")
                 if await ask_yes_no(default_yes=False):
-                    await stream.send(f"Deleting {rel_path}...", color="red")
+                    stream.send(f"Deleting {rel_path}...", color="red")
                     # We use the current lines rather than the stored lines for undo
                     self.history.add_action(
                         DeletionAction(
@@ -108,7 +106,7 @@ class CodeFileManager:
                     self._delete_file(code_context, file_edit.file_path)
                     continue
                 else:
-                    await stream.send(f"Not deleting {rel_path}", color="green")
+                    stream.send(f"Not deleting {rel_path}", color="green")
 
             if not file_edit.is_creation:
                 stored_lines = self.file_lines[rel_path]
@@ -116,13 +114,13 @@ class CodeFileManager:
                     logging.info(
                         f"File '{file_edit.file_path}' changed while generating changes"
                     )
-                    await stream.send(
+                    stream.send(
                         f"File '{rel_path}' changed while generating; current"
                         " file changes will be erased. Continue?",
                         color="light_yellow",
                     )
                     if not await ask_yes_no(default_yes=False):
-                        await stream.send(f"Not applying changes to file {rel_path}")
+                        stream.send(f"Not applying changes to file {rel_path}")
                         continue
             else:
                 stored_lines = []

--- a/mentat/code_map.py
+++ b/mentat/code_map.py
@@ -38,7 +38,7 @@ async def get_code_map(
         try:
             tag = json.loads(output_line)
         except json.decoder.JSONDecodeError as err:
-            await stream.send(
+            stream.send(
                 f"Error parsing ctags output: {err}\n{repr(output_line)}",
                 color="yellow",
             )

--- a/mentat/code_map.py
+++ b/mentat/code_map.py
@@ -6,10 +6,8 @@ from typing import Any
 
 from mentat.session_context import SESSION_CONTEXT
 
-from .utils import run_subprocess_async
 
-
-async def get_code_map(
+def get_code_map(
     root: Path, file_path: Path, exclude_signatures: bool = False
 ) -> list[str]:
     session_context = SESSION_CONTEXT.get()
@@ -28,8 +26,9 @@ async def get_code_map(
     else:
         ctags_cmd_args.append("--fields=+S")
     ctags_cmd = ["ctags", *ctags_cmd_args, str(Path(root).joinpath(file_path))]
-
-    output = await run_subprocess_async(*ctags_cmd)
+    output = subprocess.check_output(
+        ctags_cmd, stderr=subprocess.DEVNULL, start_new_session=True, text=True
+    ).strip()
     output_lines = output.splitlines()
 
     # Extract subprocess stdout into python objects
@@ -90,7 +89,7 @@ async def get_code_map(
     return output.splitlines()
 
 
-async def check_ctags_disabled() -> str | None:
+def check_ctags_disabled() -> str | None:
     try:
         cmd = ["ctags", "--version"]
         output = subprocess.check_output(cmd, stderr=subprocess.PIPE).decode("utf-8")
@@ -106,7 +105,7 @@ async def check_ctags_disabled() -> str | None:
             hello_py = Path(tempdir) / "hello.py"
             with open(hello_py, "w", encoding="utf-8") as f:
                 f.write("def hello():\n    print('Hello, world!')\n")
-            await get_code_map(Path(tempdir), hello_py)
+            get_code_map(Path(tempdir), hello_py)
         return
     except FileNotFoundError:
         return "ctags executable not found"

--- a/mentat/config_manager.py
+++ b/mentat/config_manager.py
@@ -4,7 +4,7 @@ import json
 import logging
 from json import JSONDecodeError
 from pathlib import Path
-from typing import Any, Dict, Optional, cast
+from typing import Any, Optional, cast
 
 from mentat.session_stream import SessionStream
 from mentat.utils import fetch_resource, mentat_dir_path
@@ -15,54 +15,41 @@ user_config_path = mentat_dir_path / config_file_name
 
 
 class ConfigManager:
-    def __init__(
-        self,
-        user_config: Dict[str, str],
-        project_config: Dict[str, str],
-    ):
-        self.user_config = user_config
-        self.project_config = project_config
-
-        default_config_path = fetch_resource(default_config_file_name)
-        with default_config_path.open("r") as config_file:
-            self.default_config = json.load(config_file)
-
-    @classmethod
-    async def create(cls, git_root: Path, stream: SessionStream):
+    def __init__(self, git_root: Path, stream: SessionStream):
         if user_config_path.exists():
             with open(user_config_path) as config_file:
                 try:
-                    user_config = json.load(config_file)
+                    self.user_config = json.load(config_file)
                 except JSONDecodeError:
                     logging.info("User config file contains invalid json")
-                    await stream.send(
+                    stream.send(
                         "Warning: User .mentat_config.json contains invalid"
                         " json; ignoring user configuration file",
                         color="light_yellow",
                     )
-                    user_config = dict[str, str]()
+                    self.user_config = dict[str, str]()
         else:
-            user_config = dict[str, str]()
+            self.user_config = dict[str, str]()
 
         project_config_path = git_root / config_file_name
         if project_config_path.exists():
             with open(project_config_path) as config_file:
                 try:
-                    project_config = json.load(config_file)
+                    self.project_config = json.load(config_file)
                 except JSONDecodeError:
                     logging.info("Project config file contains invalid json")
-                    await stream.send(
+                    stream.send(
                         "Warning: Git project .mentat_config.json contains invalid"
                         " json; ignoring project configuration file",
                         color="light_yellow",
                     )
-                    project_config = dict[str, str]()
+                    self.project_config = dict[str, str]()
         else:
-            project_config = dict[str, str]()
+            self.project_config = dict[str, str]()
 
-        self = cls(user_config, project_config)
-
-        return self
+        default_config_path = fetch_resource(default_config_file_name)
+        with default_config_path.open("r") as config_file:
+            self.default_config = json.load(config_file)
 
     def input_style(self) -> list[tuple[str, str]]:
         return cast(list[tuple[str, str]], self._get_key("input-style"))

--- a/mentat/conversation.py
+++ b/mentat/conversation.py
@@ -59,14 +59,14 @@ class Conversation:
                 " different model."
             )
         if "gpt-4" not in self.model:
-            await stream.send(
+            stream.send(
                 "Warning: Mentat has only been tested on GPT-4. You may experience"
                 " issues with quality. This model may not be able to respond in"
                 " mentat's edit format.",
                 color="yellow",
             )
             if "gpt-3.5" not in self.model:
-                await stream.send(
+                stream.send(
                     "Warning: Mentat does not know how to calculate costs or context"
                     " size for this model.",
                     color="yellow",
@@ -98,14 +98,14 @@ class Conversation:
                 " number of files."
             )
         elif tokens + 1000 > context_size:
-            await stream.send(
+            stream.send(
                 f"Warning: Included files are close to token limit ({tokens} /"
                 f" {context_size}), you may not be able to have a long"
                 " conversation.",
                 color="red",
             )
         else:
-            await stream.send(
+            stream.send(
                 f"Prompt and included files token count: {tokens} / {context_size}",
                 color="cyan",
             )
@@ -139,7 +139,7 @@ class Conversation:
         start_time = default_timer()
         try:
             response = await call_llm_api(messages, self.model)
-            await stream.send(
+            stream.send(
                 "Streaming... use control-c to interrupt the model at any point\n"
             )
             async with parser.interrupt_catcher():
@@ -174,12 +174,12 @@ class Conversation:
         )
         messages_snapshot.append({"role": "system", "content": code_message})
 
-        await code_context.display_features()
-        num_prompt_tokens = await get_prompt_token_count(messages_snapshot, self.model)
+        code_context.display_features()
+        num_prompt_tokens = get_prompt_token_count(messages_snapshot, self.model)
         parsedLLMResponse, time_elapsed = await self._stream_model_response(
             stream, parser, messages_snapshot
         )
-        await cost_tracker.display_api_call_stats(
+        cost_tracker.display_api_call_stats(
             num_prompt_tokens,
             count_tokens(parsedLLMResponse.full_response, self.model),
             self.model,

--- a/mentat/diff_context.py
+++ b/mentat/diff_context.py
@@ -90,32 +90,6 @@ def annotate_file_message(
 class DiffContext:
     def __init__(
         self,
-        target: Optional[str] = None,
-        name: Optional[str] = None,
-    ):
-        if target is None:
-            self.target = "HEAD"
-            self.name = "HEAD (last commit)"
-        else:
-            self.target = target
-            self.name = name
-
-    _files_cache: list[Path] | None = None
-
-    @property
-    def files(self) -> list[Path]:
-        session_context = SESSION_CONTEXT.get()
-        git_root = session_context.git_root
-
-        if self._files_cache is None:
-            if self.target == "HEAD" and not check_head_exists():
-                return []  # A new repo without any commits
-            self._files_cache = [git_root / f for f in get_files_in_diff(self.target)]
-        return self._files_cache
-
-    @classmethod
-    async def create(
-        cls,
         stream: SessionStream,
         git_root: Path,
         diff: Optional[str] = None,
@@ -124,7 +98,7 @@ class DiffContext:
         if diff and pr_diff:
             # TODO: Once broadcast queue's unread messages and/or config is moved to client,
             # determine if this should quit or not
-            await stream.send(
+            stream.send(
                 "Cannot specify more than one type of diff. Disabling diff and"
                 " pr-diff.",
                 color="light_yellow",
@@ -134,7 +108,9 @@ class DiffContext:
 
         target = diff or pr_diff
         if not target:
-            return cls()
+            self.target = "HEAD"
+            self.name = "HEAD (last commit)"
+            return
 
         name = ""
         treeish_type = _get_treeish_type(git_root, target)
@@ -148,16 +124,33 @@ class DiffContext:
             target = _git_command(git_root, "merge-base", "HEAD", pr_diff)
             if not target:
                 # TODO: Same as above todo
-                await stream.send(
+                stream.send(
                     f"Cannot identify merge base between HEAD and {pr_diff}. Disabling"
                     " pr-diff.",
                     color="light_yellow",
                 )
-                return cls()
+                self.target = "HEAD"
+                self.name = "HEAD (last commit)"
+                return
 
         meta = get_treeish_metadata(target)
         name += f'{meta["hexsha"][:8]}: {meta["summary"]}'
-        return cls(target, name)
+
+        self.target = target
+        self.name = name
+
+    _files_cache: list[Path] | None = None
+
+    @property
+    def files(self) -> list[Path]:
+        session_context = SESSION_CONTEXT.get()
+        git_root = session_context.git_root
+
+        if self._files_cache is None:
+            if self.target == "HEAD" and not check_head_exists():
+                return []  # A new repo without any commits
+            self._files_cache = [git_root / f for f in get_files_in_diff(self.target)]
+        return self._files_cache
 
     def get_display_context(self) -> str:
         if not self.files:

--- a/mentat/embeddings.py
+++ b/mentat/embeddings.py
@@ -104,7 +104,7 @@ async def get_feature_similarity_scores(
     batches = _batch_ffd(items_to_embed_tokens, EMBEDDING_MAX_TOKENS)
     for i, batch in enumerate(batches):
         batch_content = [items_to_embed[k] for k in batch]
-        await stream.send(f"Embedding batch {i}/{len(batches)}...")
+        stream.send(f"Embedding batch {i}/{len(batches)}...")
         response = call_embedding_api(batch_content, EMBEDDING_MODEL)
         for k, v in zip(batch, response):
             database[k] = v

--- a/mentat/embeddings.py
+++ b/mentat/embeddings.py
@@ -95,7 +95,7 @@ async def get_feature_similarity_scores(
         if token > EMBEDDING_MAX_TOKENS:
             continue
         if checksum not in database:
-            feature_content = await feature.get_code_message()
+            feature_content = feature.get_code_message()
             # Remove line numbering
             items_to_embed[checksum] = "\n".join(feature_content)
             items_to_embed_tokens[checksum] = token

--- a/mentat/git_handler.py
+++ b/mentat/git_handler.py
@@ -10,7 +10,7 @@ from mentat.session_context import SESSION_CONTEXT
 def get_git_diff_for_path(path: Path) -> str:
     session_context = SESSION_CONTEXT.get()
     git_root = session_context.git_root
-    return subprocess.check_output(["git", "diff", path], cwd=git_root).decode("utf-8")
+    return subprocess.check_output(["git", "diff", path], cwd=git_root, text=True)
 
 
 def get_non_gitignored_files(path: Path) -> set[Path]:

--- a/mentat/include_files.py
+++ b/mentat/include_files.py
@@ -138,7 +138,7 @@ def build_path_tree(files: list[CodeFile], git_root: Path):
     return tree
 
 
-async def print_path_tree(
+def print_path_tree(
     tree: dict[str, Any], changed_files: set[Path], cur_path: Path, prefix: str = ""
 ):
     """Prints a tree of paths, with changed files highlighted."""
@@ -149,10 +149,10 @@ async def print_path_tree(
     for i, key in enumerate(sorted(keys)):
         if i < len(keys) - 1:
             new_prefix = prefix + "│   "
-            await stream.send(f"{prefix}├── ", end="")
+            stream.send(f"{prefix}├── ", end="")
         else:
             new_prefix = prefix + "    "
-            await stream.send(f"{prefix}└── ", end="")
+            stream.send(f"{prefix}└── ", end="")
 
         cur = cur_path / key
         star = "* " if cur in changed_files else ""
@@ -162,31 +162,31 @@ async def print_path_tree(
             color = "green"
         else:
             color = None
-        await stream.send(f"{star}{key}", color=color)
+        stream.send(f"{star}{key}", color=color)
         if tree[key]:
-            await print_path_tree(tree[key], changed_files, cur, new_prefix)
+            print_path_tree(tree[key], changed_files, cur, new_prefix)
 
 
-async def print_invalid_path(invalid_path: str):
+def print_invalid_path(invalid_path: str):
     session_context = SESSION_CONTEXT.get()
     stream = session_context.stream
     git_root = session_context.git_root
 
     abs_path = Path(invalid_path).absolute()
     if "*" in invalid_path:
-        await stream.send(
+        stream.send(
             f"The glob pattern {invalid_path} did not match any files",
             color="light_red",
         )
     elif not abs_path.exists():
-        await stream.send(
+        stream.send(
             f"The path {invalid_path} does not exist and was skipped", color="light_red"
         )
     elif not is_file_text_encoded(abs_path):
         rel_path = abs_path.relative_to(git_root)
-        await stream.send(
+        stream.send(
             f"The file {rel_path} is not text encoded and was skipped",
             color="light_red",
         )
     else:
-        await stream.send(f"The file {invalid_path} was skipped", color="light_red")
+        stream.send(f"The file {invalid_path} was skipped", color="light_red")

--- a/mentat/llm_api.py
+++ b/mentat/llm_api.py
@@ -74,12 +74,12 @@ def raise_if_in_test_environment():
         raise MentatError("OpenAI call attempted in non benchmark test environment!")
 
 
-async def warn_user(message: str, max_tries: int, details: Details):
+def warn_user(message: str, max_tries: int, details: Details):
     session_context = SESSION_CONTEXT.get()
     stream = session_context.stream
 
     warning = f"{message}: Retry number {details['tries']}/{max_tries - 1}..."
-    await stream.send(warning, color="light_yellow")
+    stream.send(warning, color="light_yellow")
 
 
 @backoff.on_exception(
@@ -188,20 +188,20 @@ def model_price_per_1000_tokens(model: str) -> Optional[tuple[float, float]]:
         return None
 
 
-async def get_prompt_token_count(messages: list[dict[str, str]], model: str) -> int:
+def get_prompt_token_count(messages: list[dict[str, str]], model: str) -> int:
     session_context = SESSION_CONTEXT.get()
     stream = session_context.stream
 
     prompt_token_count = 0
     for message in messages:
         prompt_token_count += count_tokens(message["content"], model)
-    await stream.send(f"Total token count: {prompt_token_count}", color="cyan")
+    stream.send(f"Total token count: {prompt_token_count}", color="cyan")
 
     token_buffer = 500
     context_size = model_context_size(model)
     if context_size:
         if prompt_token_count > context_size - token_buffer:
-            await stream.send(
+            stream.send(
                 f"Warning: {model} has a maximum context length of {context_size}"
                 " tokens. Attempting to run anyway:",
                 color="yellow",
@@ -214,7 +214,7 @@ class CostTracker:
     total_tokens: int = 0
     total_cost: float = 0
 
-    async def display_api_call_stats(
+    def display_api_call_stats(
         self,
         num_prompt_tokens: int,
         num_sampled_tokens: int,
@@ -238,14 +238,12 @@ class CostTracker:
             )
         else:
             speed_and_cost_string = f"Speed: {tokens_per_second:.2f} tkns/s"
-        await stream.send(speed_and_cost_string, color="cyan")
+        stream.send(speed_and_cost_string, color="cyan")
 
         costs_logger = logging.getLogger("costs")
         costs_logger.info(speed_and_cost_string)
 
-    async def display_total_cost(self) -> None:
+    def display_total_cost(self) -> None:
         session_context = SESSION_CONTEXT.get()
         stream = session_context.stream
-        await stream.send(
-            f"Total session cost: ${self.total_cost:.2f}", color="light_blue"
-        )
+        stream.send(f"Total session cost: ${self.total_cost:.2f}", color="light_blue")

--- a/mentat/parsers/parser.py
+++ b/mentat/parsers/parser.py
@@ -103,7 +103,7 @@ class Parser(ABC):
             if self.shutdown.is_set():
                 printer.shutdown_printer()
                 await printer_task
-                await stream.send(
+                stream.send(
                     colored("")  # Reset ANSI codes
                     + "\n\nInterrupted by user. Using the response up to this point."
                 )

--- a/mentat/python_client/client.py
+++ b/mentat/python_client/client.py
@@ -65,7 +65,7 @@ class PythonClient:
             self._accumulated_message += message.data + end
 
     async def startup(self):
-        self.session = await Session.create(
+        self.session = Session(
             self.paths,
             self.exclude_paths,
             self.diff,

--- a/mentat/python_client/client.py
+++ b/mentat/python_client/client.py
@@ -36,7 +36,7 @@ class PythonClient:
         assert isinstance(self.session, Session), "Client is not running"
 
         input_request_message = await self.session.stream.recv("input_request")
-        await self.session.stream.send(
+        self.session.stream.send(
             message,
             source=StreamMessageSource.CLIENT,
             channel=f"input_request:{input_request_message.id}",

--- a/mentat/session.py
+++ b/mentat/session.py
@@ -1,8 +1,8 @@
 import asyncio
 import logging
-import traceback
+from asyncio import Task
 from pathlib import Path
-from typing import List, Optional, Union, cast
+from typing import List, Optional
 from uuid import uuid4
 
 from openai.error import RateLimitError, Timeout
@@ -47,9 +47,6 @@ class Session:
     ):
         self.id = uuid4()
         setup_api_key()
-
-        self._main_task: asyncio.Task[None] | None = None
-        self._stop_task: asyncio.Task[None] | None = None
 
         # Since we can't set the session_context until after all of the singletons are created,
         # any singletons used in the constructor of another singleton must be passed in
@@ -128,91 +125,35 @@ class Session:
             pass
         except (Timeout, RateLimitError) as e:
             stream.send(f"Error accessing OpenAI API: {str(e)}", color="red")
-        finally:
-            stream.send(None, channel="exit")
 
     ### lifecycle
-
-    @property
-    def is_stopped(self):
-        return self._main_task is None and self._stop_task is None
 
     def start(self) -> asyncio.Task[None]:
         """Asynchronously start the Session.
 
-        A background asyncio. Task will be created to run the startup sequence and run
+        A background asyncio Task will be created to run the startup sequence and run
         the main loop which runs forever (until a client interrupts it).
         """
-
-        if self._main_task:
-            logging.warning("Job already started")
-            return self._main_task
-
-        setup_logging()
 
         async def run_main():
             try:
                 await self._main()
-                await cast(asyncio.Task[None], self.stop())
+                await self.stop()
             except asyncio.CancelledError:
                 pass
 
-        def cleanup_main(task: asyncio.Task[None]):
-            exception = task.exception()
-            if exception is not None:
-                logging.error(f"Main task for Session({self.id}) threw an exception")
-                traceback.print_exception(
-                    type(exception), exception, exception.__traceback__
-                )
-
-            self._main_task = None
-            logging.debug("Main task stopped")
-
-        self._main_task = asyncio.create_task(run_main())
-        self._main_task.add_done_callback(cleanup_main)
-
+        setup_logging()
+        self._main_task: Task[None] = asyncio.create_task(run_main())
         return self._main_task
 
-    def stop(self) -> asyncio.Task[None] | None:
-        """Asynchronously stop the Session.
+    async def stop(self):
+        session_context = SESSION_CONTEXT.get()
+        cost_tracker = session_context.cost_tracker
 
-        A background asyncio.Task will be created that handles the shutdown sequence
-        of the Session. Clients should wait for `self.is_stopped` to return `True` in
-        order to make sure the shutdown sequence has finished.
-        """
-        if self._stop_task is not None:
-            logging.debug("Task is already stopping")
-            return self._stop_task
-        if self.is_stopped:
-            logging.debug("Task is already stopped")
-            return
-
-        async def run_stop():
-            session_context = SESSION_CONTEXT.get()
-            cost_tracker = session_context.cost_tracker
-
-            if self._main_task is None:
-                return
-            try:
-                cost_tracker.display_total_cost()
-                logging.shutdown()
-                self._main_task.cancel()
-
-                # Pyright can't see `self._main_task` being set to `None` in the task
-                # callback handler, so we have to cast the type explicitly here
-                self._main_task = cast(Union[asyncio.Task[None], None], self._main_task)
-
-                while self._main_task is not None:
-                    await asyncio.sleep(0.01)
-                self.stream.stop()
-            except asyncio.CancelledError:
-                pass
-
-        def cleanup_stop(_: asyncio.Task[None]):
-            self._stop_task = None
-            logging.debug("Task has stopped")
-
-        self._stop_task = asyncio.create_task(run_stop())
-        self._stop_task.add_done_callback(cleanup_stop)
-
-        return self._stop_task
+        cost_tracker.display_total_cost()
+        logging.shutdown()
+        self._main_task.cancel()
+        await self._main_task
+        self.stream.send(None, channel="exit")
+        await self.stream.join()
+        self.stream.stop()

--- a/mentat/session_context.py
+++ b/mentat/session_context.py
@@ -28,6 +28,3 @@ class SessionContext:
     code_context: CodeContext = attr.field()
     code_file_manager: CodeFileManager = attr.field()
     conversation: Conversation = attr.field()
-
-    def __attrs_post_init__(self):
-        SESSION_CONTEXT.set(self)

--- a/mentat/session_input.py
+++ b/mentat/session_input.py
@@ -14,7 +14,7 @@ async def _get_input_request(**kwargs: Any) -> StreamMessage:
     session_context = SESSION_CONTEXT.get()
     stream = session_context.stream
 
-    message = await stream.send("", channel="input_request", **kwargs)
+    message = stream.send("", channel="input_request", **kwargs)
     response = await stream.recv(f"input_request:{message.id}")
     return response
 
@@ -40,7 +40,7 @@ async def collect_user_input(plain: bool = False) -> StreamMessage:
                 command = Command.create_command(arguments[0])
                 await command.apply(*arguments[1:])
             except ValueError as e:
-                await stream.send(
+                stream.send(
                     f"Error processing command arguments: {e}", color="light_red"
                 )
 
@@ -59,7 +59,7 @@ async def ask_yes_no(default_yes: bool) -> bool:
 
     while True:
         # TODO: combine this into a single message (include content)
-        await stream.send("(Y/n)" if default_yes else "(y/N)")
+        stream.send("(Y/n)" if default_yes else "(y/N)")
         response = await collect_user_input(plain=True)
         content = response.data
         if content in ["y", "n", ""]:
@@ -106,7 +106,7 @@ async def listen_for_interrupt(
             return wrapped_task.result()
         else:
             # Send a newline for terminal clients (remove later)
-            await stream.send("\n")
+            stream.send("\n")
 
             if raise_exception_on_interrupt:
                 raise RemoteKeyboardInterrupt

--- a/mentat/session_stream.py
+++ b/mentat/session_stream.py
@@ -103,3 +103,7 @@ class SessionStream:
         with self._broadcast.subscribe(channel) as subscriber:
             async for event in subscriber:
                 yield event.message
+
+    async def join(self) -> None:
+        """Blocks until all sent events have been processed"""
+        await self._broadcast.join()

--- a/mentat/streaming_printer.py
+++ b/mentat/streaming_printer.py
@@ -45,7 +45,7 @@ class StreamingPrinter:
         while not self.shutdown:
             if self.strings_to_print:
                 next_string = self.strings_to_print.popleft()
-                await stream.send(next_string, end="", flush=True)
+                stream.send(next_string, end="", flush=True)
                 self.chars_remaining -= 1
             elif self.finishing:
                 break

--- a/mentat/terminal/client.py
+++ b/mentat/terminal/client.py
@@ -2,6 +2,7 @@ import argparse
 import asyncio
 import logging
 import signal
+from asyncio import Event
 from pathlib import Path
 from types import FrameType
 from typing import Any, Coroutine, List, Set
@@ -37,11 +38,8 @@ class TerminalClient:
         self.use_embedding = use_embedding
         self.auto_tokens = auto_tokens
 
-        self.session: Session | None = None
-
         self._tasks: Set[asyncio.Task[None]] = set()
-        self._should_exit = False
-        self._force_exit = False
+        self._should_exit = Event()
 
     def _create_task(self, coro: Coroutine[None, None, Any]):
         """Utility method for running a Task in the background"""
@@ -56,12 +54,10 @@ class TerminalClient:
         return task
 
     async def _cprint_session_stream(self):
-        assert isinstance(self.session, Session), "TerminalClient is not running"
         async for message in self.session.stream.listen():
             print_stream_message(message)
 
     async def _handle_input_requests(self):
-        assert isinstance(self.session, Session), "TerminalClient is not running"
         while True:
             input_request_message = await self.session.stream.recv("input_request")
             # TODO: Make extra kwargs like plain constants
@@ -72,10 +68,10 @@ class TerminalClient:
                 prompt_session = self._plain_session
             else:
                 prompt_session = self._prompt_session
+
             user_input = await prompt_session.prompt_async(handle_sigint=False)
-            assert isinstance(user_input, str)
             if user_input == "q":
-                self._should_exit = True
+                self._should_exit.set()
                 return
 
             self.session.stream.send(
@@ -84,8 +80,12 @@ class TerminalClient:
                 channel=f"input_request:{input_request_message.id}",
             )
 
+    async def _listen_for_exit(self):
+        await self.session.stream.recv("exit")
+        self._should_exit.set()
+
     async def _send_session_stream_interrupt(self):
-        assert isinstance(self.session, Session), "TerminalClient is not running"
+        logging.debug("Sending interrupt to session stream")
         self.session.stream.send(
             "", source=StreamMessageSource.CLIENT, channel="interrupt"
         )
@@ -93,30 +93,26 @@ class TerminalClient:
     # Be careful editing this function; since we use signal.signal instead of asyncio's
     # add signal handler (which isn't available on Windows), this function can interrupt
     # asyncio coroutines, potentially causing race conditions.
-    def _handle_exit(self, sig: int, frame: FrameType | None):
+    def _handle_sig_int(self, sig: int, frame: FrameType | None):
         if (
             # If session is still starting up we want to quit without an error
             not self.session
-            or self.session.is_stopped
             or self.session.stream.interrupt_lock.locked() is False
         ):
-            if self._should_exit:
+            if self._should_exit.is_set():
                 logging.debug("Force exiting client...")
-                self._force_exit = True
+                exit(0)
             else:
                 logging.debug("Should exit client...")
-                self._should_exit = True
-
+                self._should_exit.set()
         else:
-            logging.debug("Sending interrupt to session stream")
+            # We create a task here in order to avoid race conditions
             self._create_task(self._send_session_stream_interrupt())
 
     def _init_signal_handlers(self):
-        signal.signal(signal.SIGINT, self._handle_exit)
+        signal.signal(signal.SIGINT, self._handle_sig_int)
 
     async def _startup(self):
-        assert self.session is None, "TerminalClient already running"
-
         self.session = Session(
             self.paths,
             self.exclude_paths,
@@ -153,35 +149,23 @@ class TerminalClient:
         self._create_task(mentat_completer.refresh_completions())
         self._create_task(self._cprint_session_stream())
         self._create_task(self._handle_input_requests())
+        self._create_task(self._listen_for_exit())
 
         logging.debug("Completed startup")
 
     async def _shutdown(self):
-        assert isinstance(self.session, Session), "TerminalClient is not running"
-
         logging.debug("Running shutdown")
 
         # Stop session
-        self.session.stop()
-        while not self._force_exit and not self.session.is_stopped:
-            await asyncio.sleep(0.01)
-        self.session = None
-        # Logging is shutdown by session stop
+        await self.session.stop()
 
         # Stop all background tasks
         for task in self._tasks:
             task.cancel()
-        while not self._force_exit:
-            if all([task.cancelled() for task in self._tasks]):
-                break
-            await asyncio.sleep(0.01)
 
     async def _main(self):
-        assert isinstance(self.session, Session), "TerminalClient is not running"
         logging.debug("Running main loop")
-
-        while not self._should_exit and not self.session.is_stopped:
-            await asyncio.sleep(0.01)
+        await self._should_exit.wait()
 
     async def _run(self):
         self._init_signal_handlers()

--- a/mentat/terminal/client.py
+++ b/mentat/terminal/client.py
@@ -78,7 +78,7 @@ class TerminalClient:
                 self._should_exit = True
                 return
 
-            await self.session.stream.send(
+            self.session.stream.send(
                 user_input,
                 source=StreamMessageSource.CLIENT,
                 channel=f"input_request:{input_request_message.id}",
@@ -86,7 +86,7 @@ class TerminalClient:
 
     async def _send_session_stream_interrupt(self):
         assert isinstance(self.session, Session), "TerminalClient is not running"
-        await self.session.stream.send(
+        self.session.stream.send(
             "", source=StreamMessageSource.CLIENT, channel="interrupt"
         )
 

--- a/tests/benchmark_test.py
+++ b/tests/benchmark_test.py
@@ -24,7 +24,7 @@ async def edit_file_and_run(
 
     session = await Session.create(context_file_paths)
     await session.start()
-    await session.stream.stop()
+    session.stream.stop()
 
     assert os.path.exists(main_file_path)
 

--- a/tests/benchmark_test.py
+++ b/tests/benchmark_test.py
@@ -22,7 +22,7 @@ async def edit_file_and_run(
         + ["q"]
     )
 
-    session = await Session.create(context_file_paths)
+    session = Session(context_file_paths)
     await session.start()
     session.stream.stop()
 

--- a/tests/benchmarks/context_benchmark.py
+++ b/tests/benchmarks/context_benchmark.py
@@ -87,7 +87,7 @@ async def test_code_context_performance(
 
         # Create a context and run get_code_message to set the features
         settings = CodeContextSettings(use_embedding=True)
-        code_context = await CodeContext.create(["mentat/__init__.py"], [], settings)
+        code_context = CodeContext(["mentat/__init__.py"], [], settings)
         _ = await code_context.get_code_message(test["prompt"], "gpt-4", 7000)
 
         # Calculate y_pred and y_true

--- a/tests/broadcast_test.py
+++ b/tests/broadcast_test.py
@@ -5,9 +5,9 @@ from mentat.broadcast import Broadcast
 
 @pytest.mark.asyncio
 async def test_broadcast():
-    async with Broadcast() as broadcast:
-        async with broadcast.subscribe("chatroom") as subscriber:
-            await broadcast.publish("chatroom", "hello")
+    with Broadcast() as broadcast:
+        with broadcast.subscribe("chatroom") as subscriber:
+            broadcast.publish("chatroom", "hello")
             event = await subscriber.get()
             assert event.channel == "chatroom"
             assert event.message == "hello"

--- a/tests/code_context_test.py
+++ b/tests/code_context_test.py
@@ -31,7 +31,7 @@ async def test_path_gitignoring(temp_testbed, mock_session_context):
     # Run CodeFileManager on the git_testing_dir, and also explicitly pass in ignored_file_2.txt
     paths = [Path(testing_dir_path), Path(ignored_file_path_2)]
     code_context_settings = CodeContextSettings()
-    code_context = await CodeContext.create(
+    code_context = CodeContext(
         mock_session_context.stream,
         mock_session_context.git_root,
         code_context_settings,
@@ -73,7 +73,7 @@ async def test_config_glob_exclude(mocker, temp_testbed, mock_session_context):
         )
 
     code_context_settings = CodeContextSettings()
-    code_context = await CodeContext.create(
+    code_context = CodeContext(
         mock_session_context.stream,
         mock_session_context.git_root,
         code_context_settings,
@@ -105,7 +105,7 @@ async def test_glob_include(temp_testbed, mock_session_context):
 
     file_paths = ["**/*.py"]
     code_context_settings = CodeContextSettings()
-    code_context = await CodeContext.create(
+    code_context = CodeContext(
         mock_session_context.stream,
         mock_session_context.git_root,
         code_context_settings,
@@ -136,7 +136,7 @@ async def test_cli_glob_exclude(temp_testbed, mock_session_context):
     file_paths = ["**/*.py"]
     exclude_paths = ["**/*.py", "**/*.ts"]
     code_context_settings = CodeContextSettings()
-    code_context = await CodeContext.create(
+    code_context = CodeContext(
         mock_session_context.stream,
         mock_session_context.git_root,
         code_context_settings,
@@ -157,7 +157,7 @@ async def test_text_encoding_checking(temp_testbed, mock_session_context):
         f.write(bytearray([0x81]))
 
     code_context_settings = CodeContextSettings()
-    code_context = await CodeContext.create(
+    code_context = CodeContext(
         mock_session_context.stream,
         mock_session_context.git_root,
         code_context_settings,
@@ -170,7 +170,7 @@ async def test_text_encoding_checking(temp_testbed, mock_session_context):
     with open(nontext_path_requested, "wb") as f:
         # 0x81 is invalid in UTF-8 (single byte > 127), and undefined in cp1252 and iso-8859-1
         f.write(bytearray([0x81]))
-    code_context = await CodeContext.create(
+    code_context = CodeContext(
         mock_session_context.stream,
         mock_session_context.git_root,
         code_context_settings,
@@ -201,7 +201,7 @@ def features(mocker):
 @pytest.mark.asyncio
 async def test_get_code_message_cache(mocker, temp_testbed, mock_session_context):
     code_context_settings = CodeContextSettings(auto_tokens=10)
-    code_context = await CodeContext.create(
+    code_context = CodeContext(
         mock_session_context.stream,
         mock_session_context.git_root,
         code_context_settings,
@@ -250,7 +250,7 @@ async def test_get_code_message_cache(mocker, temp_testbed, mock_session_context
 @pytest.mark.asyncio
 async def test_get_code_message_include(temp_testbed, mock_session_context):
     code_context_settings = CodeContextSettings(auto_tokens=0)
-    code_context = await CodeContext.create(
+    code_context = CodeContext(
         mock_session_context.stream,
         mock_session_context.git_root,
         code_context_settings,

--- a/tests/code_context_test.py
+++ b/tests/code_context_test.py
@@ -36,7 +36,7 @@ async def test_path_gitignoring(temp_testbed, mock_session_context):
         mock_session_context.git_root,
         code_context_settings,
     )
-    await code_context.set_paths(paths, [])
+    code_context.set_paths(paths, [])
 
     expected_file_paths = [
         os.path.join(temp_testbed, ignored_file_path_2),
@@ -78,7 +78,7 @@ async def test_config_glob_exclude(mocker, temp_testbed, mock_session_context):
         mock_session_context.git_root,
         code_context_settings,
     )
-    await code_context.set_paths([Path("."), directly_added_glob_excluded_path], [])
+    code_context.set_paths([Path("."), directly_added_glob_excluded_path], [])
 
     file_paths = [str(file_path.resolve()) for file_path in code_context.include_files]
     assert os.path.join(temp_testbed, glob_exclude_path) not in file_paths
@@ -110,7 +110,7 @@ async def test_glob_include(temp_testbed, mock_session_context):
         mock_session_context.git_root,
         code_context_settings,
     )
-    await code_context.set_paths(file_paths, [])
+    code_context.set_paths(file_paths, [])
 
     file_paths = [str(file_path.resolve()) for file_path in code_context.include_files]
     assert os.path.join(temp_testbed, glob_exclude_path) not in file_paths
@@ -141,7 +141,7 @@ async def test_cli_glob_exclude(temp_testbed, mock_session_context):
         mock_session_context.git_root,
         code_context_settings,
     )
-    await code_context.set_paths(file_paths, exclude_paths)
+    code_context.set_paths(file_paths, exclude_paths)
 
     file_paths = [file_path for file_path in code_context.include_files]
     assert os.path.join(temp_testbed, glob_include_then_exclude_path) not in file_paths
@@ -162,7 +162,7 @@ async def test_text_encoding_checking(temp_testbed, mock_session_context):
         mock_session_context.git_root,
         code_context_settings,
     )
-    await code_context.set_paths(["./"], [])
+    code_context.set_paths(["./"], [])
     file_paths = [file_path for file_path in code_context.include_files]
     assert os.path.join(temp_testbed, nontext_path) not in file_paths
 
@@ -175,7 +175,7 @@ async def test_text_encoding_checking(temp_testbed, mock_session_context):
         mock_session_context.git_root,
         code_context_settings,
     )
-    await code_context.set_paths([Path(nontext_path_requested)], [])
+    code_context.set_paths([Path(nontext_path_requested)], [])
     assert not code_context.include_files
 
 
@@ -206,7 +206,7 @@ async def test_get_code_message_cache(mocker, temp_testbed, mock_session_context
         mock_session_context.git_root,
         code_context_settings,
     )
-    await code_context.set_paths(
+    code_context.set_paths(
         ["multifile_calculator"], ["multifile_calculator/calculator.py"]
     )
 
@@ -255,7 +255,7 @@ async def test_get_code_message_include(temp_testbed, mock_session_context):
         mock_session_context.git_root,
         code_context_settings,
     )
-    await code_context.set_paths(
+    code_context.set_paths(
         ["multifile_calculator"], ["multifile_calculator/calculator.py"]
     )
 

--- a/tests/code_file_manager_test.py
+++ b/tests/code_file_manager_test.py
@@ -108,7 +108,7 @@ async def test_run_from_subdirectory(
         [Path("calculator.py"), Path("../scripts")], auto_tokens=0
     )
     await session.start()
-    await session.stream.stop()
+    session.stream.stop()
 
     # Check that it works
     with open("calculator.py") as f:
@@ -154,7 +154,7 @@ async def test_change_after_creation(
 
     session = await Session.create()
     await session.start()
-    await session.stream.stop()
+    session.stream.stop()
 
     with file_name.open() as f:
         output = f.read()
@@ -191,7 +191,7 @@ async def test_changed_file(
         file_path=file_path,
         replacements=[Replacement(0, 1, ["I am a file", "with edited lines"])],
     )
-    assert await file_edit.is_valid()
+    assert file_edit.is_valid()
 
     # Decline overwrite
     mock_collect_user_input.set_stream_messages(["n", "q"])

--- a/tests/code_file_manager_test.py
+++ b/tests/code_file_manager_test.py
@@ -104,9 +104,7 @@ async def test_run_from_subdirectory(
         # Hello
         @@end""")])
 
-    session = await Session.create(
-        [Path("calculator.py"), Path("../scripts")], auto_tokens=0
-    )
+    session = Session([Path("calculator.py"), Path("../scripts")], auto_tokens=0)
     await session.start()
     session.stream.stop()
 
@@ -152,7 +150,7 @@ async def test_change_after_creation(
         print("Hello, World!")
         @@end""")])
 
-    session = await Session.create()
+    session = Session()
     await session.start()
     session.stream.stop()
 

--- a/tests/commands_test.py
+++ b/tests/commands_test.py
@@ -35,7 +35,7 @@ async def test_commit_command(
         ]
     )
 
-    session = await Session.create([])
+    session = Session([])
     await session.start()
     session.stream.stop()
 
@@ -53,7 +53,7 @@ async def test_include_command(
         ]
     )
 
-    session = await Session.create([])
+    session = Session([])
     await session.start()
     session.stream.stop()
 
@@ -74,7 +74,7 @@ async def test_exclude_command(
         ]
     )
 
-    session = await Session.create(["scripts"])
+    session = Session(["scripts"])
     await session.start()
     session.stream.stop()
 
@@ -115,7 +115,7 @@ async def test_undo_command(
         # I inserted this comment
         @@end""")])
 
-    session = await Session.create([temp_file_name])
+    session = Session([temp_file_name])
     await session.start()
     session.stream.stop()
 
@@ -161,7 +161,7 @@ async def test_undo_all_command(
         # I inserted this comment
         @@end""")])
 
-    session = await Session.create([temp_file_name])
+    session = Session([temp_file_name])
     await session.start()
     session.stream.stop()
 
@@ -186,7 +186,7 @@ async def test_clear_command(
     )
     mock_call_llm_api.set_generator_values(["Answer"])
 
-    session = await Session.create()
+    session = Session()
     await session.start()
     session.stream.stop()
 

--- a/tests/commands_test.py
+++ b/tests/commands_test.py
@@ -37,7 +37,7 @@ async def test_commit_command(
 
     session = await Session.create([])
     await session.start()
-    await session.stream.stop()
+    session.stream.stop()
 
     assert subprocess.check_output(["git", "status", "-s"], text=True) == ""
 
@@ -55,7 +55,7 @@ async def test_include_command(
 
     session = await Session.create([])
     await session.start()
-    await session.stream.stop()
+    session.stream.stop()
 
     code_context = SESSION_CONTEXT.get().code_context
     assert (
@@ -76,7 +76,7 @@ async def test_exclude_command(
 
     session = await Session.create(["scripts"])
     await session.start()
-    await session.stream.stop()
+    session.stream.stop()
 
     code_context = SESSION_CONTEXT.get().code_context
     assert not code_context.include_files
@@ -117,7 +117,7 @@ async def test_undo_command(
 
     session = await Session.create([temp_file_name])
     await session.start()
-    await session.stream.stop()
+    session.stream.stop()
 
     with open(temp_file_name, "r") as f:
         content = f.read()
@@ -163,7 +163,7 @@ async def test_undo_all_command(
 
     session = await Session.create([temp_file_name])
     await session.start()
-    await session.stream.stop()
+    session.stream.stop()
 
     with open(temp_file_name, "r") as f:
         content = f.read()
@@ -188,7 +188,7 @@ async def test_clear_command(
 
     session = await Session.create()
     await session.start()
-    await session.stream.stop()
+    session.stream.stop()
 
     conversation = SESSION_CONTEXT.get().conversation
     assert len(conversation.messages) == 1

--- a/tests/config_test.py
+++ b/tests/config_test.py
@@ -16,9 +16,7 @@ async def test_config_priority(temp_testbed, mock_session_context):
 
     # Since we don't want to actually change user config file or default config file,
     # we have to just mock them
-    config = await ConfigManager.create(
-        mock_session_context.git_root, mock_session_context.stream
-    )
+    config = ConfigManager(mock_session_context.git_root, mock_session_context.stream)
     config.user_config = {"project-first": "I will not be used", "user-second": "user"}
     config.default_config = {
         "project-first": "I also am not used",
@@ -45,8 +43,6 @@ async def test_invalid_config(temp_testbed, mock_session_context):
             "invalid-json: []]
         }"""))
 
-    config = await ConfigManager.create(
-        mock_session_context.git_root, mock_session_context.stream
-    )
+    config = ConfigManager(mock_session_context.git_root, mock_session_context.stream)
     config.user_config = {"mykey": "user"}
     assert config._get_key("mykey") == "user"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -166,11 +166,11 @@ async def _mock_session_context(temp_testbed):
     git_root = temp_testbed
 
     stream = SessionStream()
-    await stream.start()
+    stream.start()
 
     cost_tracker = CostTracker()
 
-    config = await ConfigManager.create(git_root, stream)
+    config = ConfigManager(git_root, stream)
 
     parser = parser_map[config.parser()]
 
@@ -192,7 +192,7 @@ async def _mock_session_context(temp_testbed):
         conversation,
     )
     yield session_context
-    await session_context.stream.stop()
+    session_context.stream.stop()
 
 
 @pytest.fixture

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -161,6 +161,7 @@ def add_permissions(func, path, exc_info):
 # https://github.com/pytest-dev/pytest-asyncio/issues/127
 
 
+# Despite not using any awaits here, this has to be async or there won't be a running event loop
 @pytest_asyncio.fixture()
 async def _mock_session_context(temp_testbed):
     git_root = temp_testbed
@@ -175,7 +176,7 @@ async def _mock_session_context(temp_testbed):
     parser = parser_map[config.parser()]
 
     code_context_settings = CodeContextSettings()
-    code_context = await CodeContext.create(stream, git_root, code_context_settings)
+    code_context = CodeContext(stream, git_root, code_context_settings)
 
     code_file_manager = CodeFileManager()
 

--- a/tests/diff_context_test.py
+++ b/tests/diff_context_test.py
@@ -55,7 +55,9 @@ def test_diff_context_default(temp_testbed, git_history, mock_session_context):
     abs_path = Path(temp_testbed) / "multifile_calculator" / "operations.py"
 
     # DiffContext.__init__() (default): active code vs last commit
-    diff_context = DiffContext()
+    diff_context = DiffContext(
+        mock_session_context.stream, mock_session_context.git_root
+    )
     assert diff_context.target == "HEAD"
     assert diff_context.name == "HEAD (last commit)"
     assert diff_context.files == []
@@ -83,7 +85,7 @@ async def test_diff_context_commit(temp_testbed, git_history, mock_session_conte
     last_commit = subprocess.check_output(
         ["git", "rev-parse", "HEAD~2"], cwd=temp_testbed, text=True
     ).strip()
-    diff_context = await DiffContext.create(
+    diff_context = DiffContext(
         mock_session_context.stream, mock_session_context.git_root, diff=last_commit
     )
     assert diff_context.target == last_commit
@@ -101,7 +103,7 @@ async def test_diff_context_commit(temp_testbed, git_history, mock_session_conte
 
 @pytest.mark.asyncio
 async def test_diff_context_branch(temp_testbed, git_history, mock_session_context):
-    diff_context = await DiffContext.create(
+    diff_context = DiffContext(
         mock_session_context.stream, mock_session_context.git_root, diff="test_branch"
     )
     abs_path = Path(temp_testbed) / "multifile_calculator" / "operations.py"
@@ -122,7 +124,7 @@ async def test_diff_context_branch(temp_testbed, git_history, mock_session_conte
 
 @pytest.mark.asyncio
 async def test_diff_context_relative(temp_testbed, git_history, mock_session_context):
-    diff_context = await DiffContext.create(
+    diff_context = DiffContext(
         mock_session_context.stream, mock_session_context.git_root, diff="HEAD~2"
     )
     abs_path = Path(temp_testbed) / "multifile_calculator" / "operations.py"
@@ -146,7 +148,7 @@ async def test_diff_context_pr(temp_testbed, git_history, mock_session_context):
     abs_path = Path(temp_testbed) / "multifile_calculator" / "operations.py"
 
     subprocess.run(["git", "checkout", "test_branch"], cwd=temp_testbed)
-    diff_context = await DiffContext.create(
+    diff_context = DiffContext(
         mock_session_context.stream, mock_session_context.git_root, pr_diff="master"
     )
 

--- a/tests/parser_tests/block_format_error_test.py
+++ b/tests/parser_tests/block_format_error_test.py
@@ -64,7 +64,7 @@ async def error_test_template(
     )
     mock_call_llm_api.set_generator_values([changes])
 
-    session = await Session.create([temp_file_name])
+    session = Session([temp_file_name])
     await session.start()
     session.stream.stop()
     with open(temp_file_name, "r") as f:

--- a/tests/parser_tests/block_format_error_test.py
+++ b/tests/parser_tests/block_format_error_test.py
@@ -66,7 +66,7 @@ async def error_test_template(
 
     session = await Session.create([temp_file_name])
     await session.start()
-    await session.stream.stop()
+    session.stream.stop()
     with open(temp_file_name, "r") as f:
         content = f.read()
     return content

--- a/tests/parser_tests/block_format_test.py
+++ b/tests/parser_tests/block_format_test.py
@@ -50,7 +50,7 @@ async def test_insert(mock_call_llm_api, mock_collect_user_input, mock_setup_api
         @@end""".format(file_name=temp_file_name))])
 
     # Run the system with the temporary file path
-    session = await Session.create([temp_file_name])
+    session = Session([temp_file_name])
     await session.start()
     session.stream.stop()
 
@@ -98,7 +98,7 @@ async def test_replace(mock_call_llm_api, mock_collect_user_input, mock_setup_ap
         @@end""".format(file_name=temp_file_name))])
 
     # Run the system with the temporary file path
-    session = await Session.create([temp_file_name])
+    session = Session([temp_file_name])
     await session.start()
     session.stream.stop()
 
@@ -144,7 +144,7 @@ async def test_delete(mock_call_llm_api, mock_collect_user_input, mock_setup_api
         @@end""".format(file_name=temp_file_name))])
 
     # Run the system with the temporary file path
-    session = await Session.create([temp_file_name])
+    session = Session([temp_file_name])
     await session.start()
     session.stream.stop()
 
@@ -185,7 +185,7 @@ async def test_create_file(
         # I created this file
         @@end""".format(file_name=temp_file_name))])
 
-    session = await Session.create(["."])
+    session = Session(["."])
     await session.start()
     session.stream.stop()
 
@@ -228,7 +228,7 @@ async def test_delete_file(
         @@end""".format(file_name=temp_file_name))])
 
     # Run the system with the temporary file path
-    session = await Session.create([temp_file_name])
+    session = Session([temp_file_name])
     await session.start()
     session.stream.stop()
 
@@ -266,7 +266,7 @@ async def test_rename_file(
         }}
         @@end""")])
 
-    session = await Session.create([temp_file_name])
+    session = Session([temp_file_name])
     await session.start()
     session.stream.stop()
     with open(temp_2_file_name) as new_file:
@@ -319,7 +319,7 @@ async def test_change_then_rename_file(
         }}
         @@end""")])
 
-    session = await Session.create([temp_file_name])
+    session = Session([temp_file_name])
     await session.start()
     session.stream.stop()
     with open(temp_2_file_name) as new_file:
@@ -372,7 +372,7 @@ async def test_rename_file_then_change(
         # I inserted this comment!
         @@end""")])
 
-    session = await Session.create([temp_file_name])
+    session = Session([temp_file_name])
     await session.start()
     session.stream.stop()
     with open(temp_2_file_name) as new_file:
@@ -433,7 +433,7 @@ async def test_multiple_blocks(
         @@end""".format(file_name=temp_file_name))])
 
     # Run the system with the temporary file path
-    session = await Session.create([temp_file_name])
+    session = Session([temp_file_name])
     await session.start()
     session.stream.stop()
 
@@ -499,7 +499,7 @@ async def test_json_strings(
         @@end""".format(file_name=temp_file_name))])
 
     # Run the system with the temporary file path
-    session = await Session.create([temp_file_name])
+    session = Session([temp_file_name])
     await session.start()
     session.stream.stop()
 

--- a/tests/parser_tests/block_format_test.py
+++ b/tests/parser_tests/block_format_test.py
@@ -52,7 +52,7 @@ async def test_insert(mock_call_llm_api, mock_collect_user_input, mock_setup_api
     # Run the system with the temporary file path
     session = await Session.create([temp_file_name])
     await session.start()
-    await session.stream.stop()
+    session.stream.stop()
 
     # Check if the temporary file is modified as expected
     with open(temp_file_name, "r") as f:
@@ -100,7 +100,7 @@ async def test_replace(mock_call_llm_api, mock_collect_user_input, mock_setup_ap
     # Run the system with the temporary file path
     session = await Session.create([temp_file_name])
     await session.start()
-    await session.stream.stop()
+    session.stream.stop()
 
     # Check if the temporary file is modified as expected
     with open(temp_file_name, "r") as f:
@@ -146,7 +146,7 @@ async def test_delete(mock_call_llm_api, mock_collect_user_input, mock_setup_api
     # Run the system with the temporary file path
     session = await Session.create([temp_file_name])
     await session.start()
-    await session.stream.stop()
+    session.stream.stop()
 
     # Check if the temporary file is modified as expected
     with open(temp_file_name, "r") as f:
@@ -187,7 +187,7 @@ async def test_create_file(
 
     session = await Session.create(["."])
     await session.start()
-    await session.stream.stop()
+    session.stream.stop()
 
     # Check if the temporary file is modified as expected
     with open(temp_file_name, "r") as f:
@@ -230,7 +230,7 @@ async def test_delete_file(
     # Run the system with the temporary file path
     session = await Session.create([temp_file_name])
     await session.start()
-    await session.stream.stop()
+    session.stream.stop()
 
     # Check if the temporary file is modified as expected
     assert not os.path.exists(temp_file_name)
@@ -268,7 +268,7 @@ async def test_rename_file(
 
     session = await Session.create([temp_file_name])
     await session.start()
-    await session.stream.stop()
+    session.stream.stop()
     with open(temp_2_file_name) as new_file:
         content = new_file.read()
         expected_content = "# Move me!"
@@ -321,7 +321,7 @@ async def test_change_then_rename_file(
 
     session = await Session.create([temp_file_name])
     await session.start()
-    await session.stream.stop()
+    session.stream.stop()
     with open(temp_2_file_name) as new_file:
         content = new_file.read()
         expected_content = "# I inserted this comment!\n# Move me!"
@@ -374,7 +374,7 @@ async def test_rename_file_then_change(
 
     session = await Session.create([temp_file_name])
     await session.start()
-    await session.stream.stop()
+    session.stream.stop()
     with open(temp_2_file_name) as new_file:
         content = new_file.read()
         expected_content = "# I inserted this comment!\n# Move me!"
@@ -435,7 +435,7 @@ async def test_multiple_blocks(
     # Run the system with the temporary file path
     session = await Session.create([temp_file_name])
     await session.start()
-    await session.stream.stop()
+    session.stream.stop()
 
     # Check if the temporary file is modified as expected
     with open(temp_file_name, "r") as f:
@@ -501,7 +501,7 @@ async def test_json_strings(
     # Run the system with the temporary file path
     session = await Session.create([temp_file_name])
     await session.start()
-    await session.stream.stop()
+    session.stream.stop()
 
     # Check if the temporary file is modified as expected
     with open(temp_file_name, "r") as f:

--- a/tests/parser_tests/file_edit_test.py
+++ b/tests/parser_tests/file_edit_test.py
@@ -15,7 +15,7 @@ async def test_replacement(mock_session_context):
         Replacement(3, 3, ["# Inserted"]),
     ]
     file_edit = FileEdit(file_path=Path("test.py"), replacements=replacements)
-    await file_edit.resolve_conflicts()
+    file_edit.resolve_conflicts()
     original_lines = ["# Remove me", "# Remove me", "# Line 3", "# Line 4"]
     new_lines = file_edit.get_updated_file_lines(original_lines)
     assert new_lines == [
@@ -38,7 +38,7 @@ async def test_replacement_conflict(mock_session_context):
         Replacement(5, 6, ["L2"]),
     ]
     file_edit = FileEdit(file_path=Path("test.py"), replacements=replacements)
-    await file_edit.resolve_conflicts()
+    file_edit.resolve_conflicts()
     original_lines = ["O0", "O1", "O2", "O3", "O4", "O5", "O6"]
     new_lines = file_edit.get_updated_file_lines(original_lines)
     assert new_lines == ["L0", "L1", "O3", "L2", "L3"]

--- a/tests/parser_tests/replacement_format_error_test.py
+++ b/tests/parser_tests/replacement_format_error_test.py
@@ -45,7 +45,7 @@ async def test_invalid_line_numbers(
 
     session = await Session.create([temp_file_name])
     await session.start()
-    await session.stream.stop()
+    session.stream.stop()
     with open(temp_file_name, "r") as f:
         content = f.read()
         expected_content = dedent("""\
@@ -87,7 +87,7 @@ async def test_invalid_special_line(
 
     session = await Session.create([temp_file_name])
     await session.start()
-    await session.stream.stop()
+    session.stream.stop()
     with open(temp_file_name, "r") as f:
         content = f.read()
         expected_content = dedent("""\

--- a/tests/parser_tests/replacement_format_error_test.py
+++ b/tests/parser_tests/replacement_format_error_test.py
@@ -43,7 +43,7 @@ async def test_invalid_line_numbers(
         # I also will not be used
         @""")])
 
-    session = await Session.create([temp_file_name])
+    session = Session([temp_file_name])
     await session.start()
     session.stream.stop()
     with open(temp_file_name, "r") as f:
@@ -85,7 +85,7 @@ async def test_invalid_special_line(
         # I will not be used
         @""")])
 
-    session = await Session.create([temp_file_name])
+    session = Session([temp_file_name])
     await session.start()
     session.stream.stop()
     with open(temp_file_name, "r") as f:

--- a/tests/parser_tests/replacement_format_test.py
+++ b/tests/parser_tests/replacement_format_test.py
@@ -38,7 +38,7 @@ async def test_insert(mock_call_llm_api, mock_collect_user_input, mock_setup_api
         # I inserted this comment
         @""")])
 
-    session = await Session.create([temp_file_name])
+    session = Session([temp_file_name])
     await session.start()
     session.stream.stop()
     with open(temp_file_name, "r") as f:
@@ -71,7 +71,7 @@ async def test_delete(mock_call_llm_api, mock_collect_user_input, mock_setup_api
         @ {temp_file_name} starting_line=1 ending_line=1
         @""")])
 
-    session = await Session.create([temp_file_name])
+    session = Session([temp_file_name])
     await session.start()
     session.stream.stop()
     with open(temp_file_name, "r") as f:
@@ -103,7 +103,7 @@ async def test_replace(mock_call_llm_api, mock_collect_user_input, mock_setup_ap
         # I inserted this comment
         @""")])
 
-    session = await Session.create([temp_file_name])
+    session = Session([temp_file_name])
     await session.start()
     session.stream.stop()
     with open(temp_file_name, "r") as f:
@@ -134,7 +134,7 @@ async def test_create_file(
         # New line
         @""")])
 
-    session = await Session.create([temp_file_name])
+    session = Session([temp_file_name])
     await session.start()
     session.stream.stop()
     with open(temp_file_name, "r") as f:
@@ -167,7 +167,7 @@ async def test_delete_file(
 
         @ {temp_file_name} -""")])
 
-    session = await Session.create([temp_file_name])
+    session = Session([temp_file_name])
     await session.start()
     session.stream.stop()
     assert not Path(temp_file_name).exists()
@@ -196,7 +196,7 @@ async def test_rename_file(
 
         @ {temp_file_name} {temp_file_name_2}""")])
 
-    session = await Session.create([temp_file_name])
+    session = Session([temp_file_name])
     await session.start()
     session.stream.stop()
     assert not Path(temp_file_name).exists()
@@ -237,7 +237,7 @@ async def test_change_then_rename_then_change(
         # New line 2
         @""")])
 
-    session = await Session.create([temp_file_name])
+    session = Session([temp_file_name])
     await session.start()
     session.stream.stop()
     assert not Path(temp_file_name).exists()

--- a/tests/parser_tests/replacement_format_test.py
+++ b/tests/parser_tests/replacement_format_test.py
@@ -40,7 +40,7 @@ async def test_insert(mock_call_llm_api, mock_collect_user_input, mock_setup_api
 
     session = await Session.create([temp_file_name])
     await session.start()
-    await session.stream.stop()
+    session.stream.stop()
     with open(temp_file_name, "r") as f:
         content = f.read()
         expected_content = dedent("""\
@@ -73,7 +73,7 @@ async def test_delete(mock_call_llm_api, mock_collect_user_input, mock_setup_api
 
     session = await Session.create([temp_file_name])
     await session.start()
-    await session.stream.stop()
+    session.stream.stop()
     with open(temp_file_name, "r") as f:
         content = f.read()
         expected_content = dedent("""\
@@ -105,7 +105,7 @@ async def test_replace(mock_call_llm_api, mock_collect_user_input, mock_setup_ap
 
     session = await Session.create([temp_file_name])
     await session.start()
-    await session.stream.stop()
+    session.stream.stop()
     with open(temp_file_name, "r") as f:
         content = f.read()
         expected_content = dedent("""\
@@ -136,7 +136,7 @@ async def test_create_file(
 
     session = await Session.create([temp_file_name])
     await session.start()
-    await session.stream.stop()
+    session.stream.stop()
     with open(temp_file_name, "r") as f:
         content = f.read()
         expected_content = dedent("""\
@@ -169,7 +169,7 @@ async def test_delete_file(
 
     session = await Session.create([temp_file_name])
     await session.start()
-    await session.stream.stop()
+    session.stream.stop()
     assert not Path(temp_file_name).exists()
 
 
@@ -198,7 +198,7 @@ async def test_rename_file(
 
     session = await Session.create([temp_file_name])
     await session.start()
-    await session.stream.stop()
+    session.stream.stop()
     assert not Path(temp_file_name).exists()
     with open(temp_file_name_2, "r") as f:
         content = f.read()
@@ -239,7 +239,7 @@ async def test_change_then_rename_then_change(
 
     session = await Session.create([temp_file_name])
     await session.start()
-    await session.stream.stop()
+    session.stream.stop()
     assert not Path(temp_file_name).exists()
     with open(temp_file_name_2, "r") as f:
         content = f.read()

--- a/tests/parser_tests/split_diff_format_error_test.py
+++ b/tests/parser_tests/split_diff_format_error_test.py
@@ -57,7 +57,7 @@ async def test_no_matching_lines(
 
     session = await Session.create([temp_file_name])
     await session.start()
-    await session.stream.stop()
+    session.stream.stop()
     with open(temp_file_name, "r") as f:
         content = f.read()
         expected_content = dedent("""\

--- a/tests/parser_tests/split_diff_format_error_test.py
+++ b/tests/parser_tests/split_diff_format_error_test.py
@@ -55,7 +55,7 @@ async def test_no_matching_lines(
         >>>>>>> updated
         {{fence[1]}}""")])
 
-    session = await Session.create([temp_file_name])
+    session = Session([temp_file_name])
     await session.start()
     session.stream.stop()
     with open(temp_file_name, "r") as f:

--- a/tests/parser_tests/split_diff_format_test.py
+++ b/tests/parser_tests/split_diff_format_test.py
@@ -48,7 +48,7 @@ async def test_replacement(
         >>>>>>> updated
         {{fence[1]}}""")])
 
-    session = await Session.create([temp_file_name])
+    session = Session([temp_file_name])
     await session.start()
     session.stream.stop()
     with open(temp_file_name, "r") as f:
@@ -95,7 +95,7 @@ async def test_replacement_case_not_matching(
         >>>>>>> updated
         {{fence[1]}}""")])
 
-    session = await Session.create([temp_file_name])
+    session = Session([temp_file_name])
     await session.start()
     session.stream.stop()
     with open(temp_file_name, "r") as f:
@@ -140,7 +140,7 @@ async def test_replacement_whitespace_not_matching(
         >>>>>>> updated
         {{fence[1]}}""")])
 
-    session = await Session.create([temp_file_name])
+    session = Session([temp_file_name])
     await session.start()
     session.stream.stop()
     with open(temp_file_name, "r") as f:
@@ -170,7 +170,7 @@ async def test_file_creation(
 
         {{fence[0]}} {temp_file_name} +""")])
 
-    session = await Session.create([temp_file_name])
+    session = Session([temp_file_name])
     await session.start()
     session.stream.stop()
     assert Path(temp_file_name).exists()
@@ -201,7 +201,7 @@ async def test_file_deletion(
 
         {{fence[0]}} {temp_file_name} -""")])
 
-    session = await Session.create([temp_file_name])
+    session = Session([temp_file_name])
     await session.start()
     session.stream.stop()
     assert not Path(temp_file_name).exists()
@@ -232,7 +232,7 @@ async def test_file_rename(
 
         {{fence[0]}} {temp_file_name} -> {temp_file_name_2}""")])
 
-    session = await Session.create([temp_file_name])
+    session = Session([temp_file_name])
     await session.start()
     session.stream.stop()
     with open(temp_file_name_2, "r") as f:

--- a/tests/parser_tests/split_diff_format_test.py
+++ b/tests/parser_tests/split_diff_format_test.py
@@ -50,7 +50,7 @@ async def test_replacement(
 
     session = await Session.create([temp_file_name])
     await session.start()
-    await session.stream.stop()
+    session.stream.stop()
     with open(temp_file_name, "r") as f:
         content = f.read()
         expected_content = dedent("""\
@@ -97,7 +97,7 @@ async def test_replacement_case_not_matching(
 
     session = await Session.create([temp_file_name])
     await session.start()
-    await session.stream.stop()
+    session.stream.stop()
     with open(temp_file_name, "r") as f:
         content = f.read()
         expected_content = dedent("""\
@@ -142,7 +142,7 @@ async def test_replacement_whitespace_not_matching(
 
     session = await Session.create([temp_file_name])
     await session.start()
-    await session.stream.stop()
+    session.stream.stop()
     with open(temp_file_name, "r") as f:
         content = f.read()
         expected_content = dedent("""\
@@ -172,7 +172,7 @@ async def test_file_creation(
 
     session = await Session.create([temp_file_name])
     await session.start()
-    await session.stream.stop()
+    session.stream.stop()
     assert Path(temp_file_name).exists()
 
 
@@ -203,7 +203,7 @@ async def test_file_deletion(
 
     session = await Session.create([temp_file_name])
     await session.start()
-    await session.stream.stop()
+    session.stream.stop()
     assert not Path(temp_file_name).exists()
 
 
@@ -234,7 +234,7 @@ async def test_file_rename(
 
     session = await Session.create([temp_file_name])
     await session.start()
-    await session.stream.stop()
+    session.stream.stop()
     with open(temp_file_name_2, "r") as f:
         content = f.read()
         expected_content = dedent("""\

--- a/tests/parser_tests/unified_diff_format_error_test.py
+++ b/tests/parser_tests/unified_diff_format_error_test.py
@@ -43,7 +43,7 @@ async def test_not_matching(
         +# your captain speaking
          # 4 lines""")])
 
-    session = await Session.create([temp_file_name])
+    session = Session([temp_file_name])
     await session.start()
     session.stream.stop()
     with open(temp_file_name, "r") as f:
@@ -87,7 +87,7 @@ async def test_no_prefix(
         +# your captain speaking
         # 4 lines""")])
 
-    session = await Session.create([temp_file_name])
+    session = Session([temp_file_name])
     await session.start()
     session.stream.stop()
     with open(temp_file_name, "r") as f:

--- a/tests/parser_tests/unified_diff_format_error_test.py
+++ b/tests/parser_tests/unified_diff_format_error_test.py
@@ -45,7 +45,7 @@ async def test_not_matching(
 
     session = await Session.create([temp_file_name])
     await session.start()
-    await session.stream.stop()
+    session.stream.stop()
     with open(temp_file_name, "r") as f:
         content = f.read()
         expected_content = dedent("""\
@@ -89,7 +89,7 @@ async def test_no_prefix(
 
     session = await Session.create([temp_file_name])
     await session.start()
-    await session.stream.stop()
+    session.stream.stop()
     with open(temp_file_name, "r") as f:
         content = f.read()
         expected_content = dedent("""\

--- a/tests/parser_tests/unified_diff_format_test.py
+++ b/tests/parser_tests/unified_diff_format_test.py
@@ -48,7 +48,7 @@ async def test_replacement(
 
     session = await Session.create([temp_file_name])
     await session.start()
-    await session.stream.stop()
+    session.stream.stop()
     with open(temp_file_name, "r") as f:
         content = f.read()
         expected_content = dedent("""\
@@ -102,7 +102,7 @@ async def test_multiple_replacements(
 
     session = await Session.create([temp_file_name])
     await session.start()
-    await session.stream.stop()
+    session.stream.stop()
     with open(temp_file_name, "r") as f:
         content = f.read()
         expected_content = dedent("""\
@@ -156,7 +156,7 @@ async def test_multiple_replacement_spots(
 
     session = await Session.create([temp_file_name])
     await session.start()
-    await session.stream.stop()
+    session.stream.stop()
     with open(temp_file_name, "r") as f:
         content = f.read()
         expected_content = dedent("""\
@@ -209,7 +209,7 @@ async def test_little_context_addition(
 
     session = await Session.create([temp_file_name])
     await session.start()
-    await session.stream.stop()
+    session.stream.stop()
     with open(temp_file_name, "r") as f:
         content = f.read()
         expected_content = dedent("""\
@@ -253,7 +253,7 @@ async def test_empty_file(
 
     session = await Session.create([temp_file_name])
     await session.start()
-    await session.stream.stop()
+    session.stream.stop()
     with open(temp_file_name, "r") as f:
         content = f.read()
         expected_content = dedent("""\
@@ -286,7 +286,7 @@ async def test_creation(mock_call_llm_api, mock_collect_user_input, mock_setup_a
 
     session = await Session.create([temp_file_name])
     await session.start()
-    await session.stream.stop()
+    session.stream.stop()
     with open(temp_file_name, "r") as f:
         content = f.read()
         expected_content = dedent("""\
@@ -325,7 +325,7 @@ async def test_deletion(mock_call_llm_api, mock_collect_user_input, mock_setup_a
 
     session = await Session.create([temp_file_name])
     await session.start()
-    await session.stream.stop()
+    session.stream.stop()
     assert not temp_file_name.exists()
 
 
@@ -362,7 +362,7 @@ async def test_no_ending_marker(
 
     session = await Session.create([temp_file_name])
     await session.start()
-    await session.stream.stop()
+    session.stream.stop()
     with open(temp_file_name, "r") as f:
         content = f.read()
         expected_content = dedent("""\

--- a/tests/parser_tests/unified_diff_format_test.py
+++ b/tests/parser_tests/unified_diff_format_test.py
@@ -46,7 +46,7 @@ async def test_replacement(
          # 4 lines
         @@ end @@""")])
 
-    session = await Session.create([temp_file_name])
+    session = Session([temp_file_name])
     await session.start()
     session.stream.stop()
     with open(temp_file_name, "r") as f:
@@ -100,7 +100,7 @@ async def test_multiple_replacements(
          # lines
         @@ end @@""")])
 
-    session = await Session.create([temp_file_name])
+    session = Session([temp_file_name])
     await session.start()
     session.stream.stop()
     with open(temp_file_name, "r") as f:
@@ -154,7 +154,7 @@ async def test_multiple_replacement_spots(
         +# more than
         @@ end @@""")])
 
-    session = await Session.create([temp_file_name])
+    session = Session([temp_file_name])
     await session.start()
     session.stream.stop()
     with open(temp_file_name, "r") as f:
@@ -207,7 +207,7 @@ async def test_little_context_addition(
          # with 
         @@ end @@""")])
 
-    session = await Session.create([temp_file_name])
+    session = Session([temp_file_name])
     await session.start()
     session.stream.stop()
     with open(temp_file_name, "r") as f:
@@ -251,7 +251,7 @@ async def test_empty_file(
         +# line
         @@ end @@""")])
 
-    session = await Session.create([temp_file_name])
+    session = Session([temp_file_name])
     await session.start()
     session.stream.stop()
     with open(temp_file_name, "r") as f:
@@ -284,7 +284,7 @@ async def test_creation(mock_call_llm_api, mock_collect_user_input, mock_setup_a
         @@ end @@
         """)])
 
-    session = await Session.create([temp_file_name])
+    session = Session([temp_file_name])
     await session.start()
     session.stream.stop()
     with open(temp_file_name, "r") as f:
@@ -323,7 +323,7 @@ async def test_deletion(mock_call_llm_api, mock_collect_user_input, mock_setup_a
         +++ /dev/null
         @@ end @@""")])
 
-    session = await Session.create([temp_file_name])
+    session = Session([temp_file_name])
     await session.start()
     session.stream.stop()
     assert not temp_file_name.exists()
@@ -360,7 +360,7 @@ async def test_no_ending_marker(
         +# your captain speaking
          # 4 lines""")])
 
-    session = await Session.create([temp_file_name])
+    session = Session([temp_file_name])
     await session.start()
     session.stream.stop()
     with open(temp_file_name, "r") as f:

--- a/tests/system_test.py
+++ b/tests/system_test.py
@@ -42,7 +42,7 @@ async def test_system(mock_call_llm_api, mock_setup_api_key, mock_collect_user_i
         print("Hello, world!")
         @@end""".format(file_name=temp_file_name))])
 
-    session = await Session.create([temp_file_name])
+    session = Session([temp_file_name])
     await session.start()
     session.stream.stop()
 
@@ -112,7 +112,7 @@ async def test_interactive_change_selection(
         print("Change 3")
         @@end""".format(file_name=temp_file_name))])
 
-    session = await Session.create([temp_file_name])
+    session = Session([temp_file_name])
     await session.start()
     session.stream.stop()
 
@@ -156,7 +156,7 @@ async def test_without_os_join(
         @@code
         print("Hello, world!")
         @@end""".format(file_name=fake_file_path))])
-    session = await Session.create([temp_file_path])
+    session = Session([temp_file_path])
     await session.start()
     session.stream.stop()
     mock_collect_user_input.reset_mock()
@@ -195,7 +195,7 @@ async def test_sub_directory(
             print("Hello, world!")
             @@end""")])
 
-        session = await Session.create([file_name])
+        session = Session([file_name])
         await session.start()
         session.stream.stop()
 

--- a/tests/system_test.py
+++ b/tests/system_test.py
@@ -44,7 +44,7 @@ async def test_system(mock_call_llm_api, mock_setup_api_key, mock_collect_user_i
 
     session = await Session.create([temp_file_name])
     await session.start()
-    await session.stream.stop()
+    session.stream.stop()
 
     # Check if the temporary file is modified as expected
     with open(temp_file_name, "r") as f:
@@ -114,7 +114,7 @@ async def test_interactive_change_selection(
 
     session = await Session.create([temp_file_name])
     await session.start()
-    await session.stream.stop()
+    session.stream.stop()
 
     # Check if the temporary file is modified as expected
     with open(temp_file_name, "r") as f:
@@ -158,7 +158,7 @@ async def test_without_os_join(
         @@end""".format(file_name=fake_file_path))])
     session = await Session.create([temp_file_path])
     await session.start()
-    await session.stream.stop()
+    session.stream.stop()
     mock_collect_user_input.reset_mock()
     with open(temp_file_path, "r") as f:
         content = f.read()
@@ -197,7 +197,7 @@ async def test_sub_directory(
 
         session = await Session.create([file_name])
         await session.start()
-        await session.stream.stop()
+        session.stream.stop()
 
         # Check if the temporary file is modified as expected
         with open(file_name, "r") as f:


### PR DESCRIPTION
Removes async from stream.send as well as changing the async subprocess call to a regular subprocess call; this removes almost all of the async code apart from contacting the model or the user (which are the places where async makes sense). @waydegg I can't remember why we decided to use an async subprocess call for ctags instead of a regular subprocess call; let me know if this messes something up.

Also cleans up some of the async code related to the session and client lifetimes as well as adding an 'exit' message that the stream can send to the client to indicate that it's shutting down.