### PR TITLE
Remove git dependency for CodeMap

### DIFF
--- a/mentat/code_feature.py
+++ b/mentat/code_feature.py
@@ -32,7 +32,7 @@ def split_file_into_intervals(
         return [feature]
 
     # Get ctags data (name and start line) and determine end line
-    ctags = list(get_ctags(git_root, feature.path))
+    ctags = list(get_ctags(git_root.joinpath(feature.path)))
     ctags = sorted(ctags, key=lambda x: int(x[4]))  # type: ignore
     named_intervals = list[tuple[str, int, int]]()  # Name, Start, End
     _last_item = tuple[str, int]()
@@ -170,10 +170,10 @@ class CodeFeature:
                     else:
                         code_message.append(f"{line}")
         elif self.level == CodeMessageLevel.CMAP_FULL:
-            cmap = get_code_map(git_root, self.path)
+            cmap = get_code_map(git_root.joinpath(self.path))
             code_message += cmap
         elif self.level == CodeMessageLevel.CMAP:
-            cmap = get_code_map(git_root, self.path, exclude_signatures=True)
+            cmap = get_code_map(git_root.joinpath(self.path), exclude_signatures=True)
             code_message += cmap
         code_message.append("")
 

--- a/mentat/code_map.py
+++ b/mentat/code_map.py
@@ -8,7 +8,7 @@ from mentat.session_context import SESSION_CONTEXT
 
 
 def get_ctags(
-    root: Path, file_path: Path, exclude_signatures: bool = False
+    abs_file_path: Path, exclude_signatures: bool = False
 ) -> set[tuple[str | int | None, ...]]:
     session_context = SESSION_CONTEXT.get()
     stream = session_context.stream
@@ -25,7 +25,7 @@ def get_ctags(
         ctags_cmd_args.append("--fields=-s")
     else:
         ctags_cmd_args.append("--fields=+S")
-    ctags_cmd = ["ctags", *ctags_cmd_args, str(Path(root).joinpath(file_path))]
+    ctags_cmd = ["ctags", *ctags_cmd_args, str(abs_file_path)]
     output = subprocess.check_output(
         ctags_cmd, stderr=subprocess.DEVNULL, start_new_session=True, text=True
     ).strip()
@@ -95,10 +95,8 @@ def _make_ctags_human_readable(ctags: set[tuple[Any, ...]]) -> list[str]:
     return output.splitlines()
 
 
-def get_code_map(
-    root: Path, file_path: Path, exclude_signatures: bool = False
-) -> list[str]:
-    ctags = get_ctags(root, file_path, exclude_signatures)
+def get_code_map(abs_file_path: Path, exclude_signatures: bool = False) -> list[str]:
+    ctags = get_ctags(abs_file_path, exclude_signatures)
     if not ctags:
         return []
     return _make_ctags_human_readable(ctags)
@@ -120,7 +118,7 @@ def check_ctags_disabled() -> str | None:
             hello_py = Path(tempdir) / "hello.py"
             with open(hello_py, "w", encoding="utf-8") as f:
                 f.write("def hello():\n    print('Hello, world!')\n")
-            get_code_map(Path(tempdir), hello_py)
+            get_code_map(hello_py)
         return
     except FileNotFoundError:
         return "ctags executable not found"

--- a/tests/benchmarks/context_benchmark.py
+++ b/tests/benchmarks/context_benchmark.py
@@ -26,6 +26,7 @@ An auto-context process might look like this:
 These tests can be used to train/score #1 or #2, but we'd expect #2 to score 
 a lot higher.
 """
+
 import os
 import subprocess
 from pathlib import Path

--- a/tests/code_feature_test.py
+++ b/tests/code_feature_test.py
@@ -6,15 +6,20 @@ from mentat.code_feature import CodeFeature, CodeMessageLevel, split_file_into_i
 
 def test_split_file_into_intervals(temp_testbed, mock_session_context):
     with open("file_1.py", "w") as f:
-        f.write(dedent("""\
+        f.write(
+            dedent(
+                """\
             def func_1(x, y):
                 return x + y
             
             def func_2():
                 return 3
-            """))
+            """
+            )
+        )
     code_feature = CodeFeature(Path("file_1.py"), CodeMessageLevel.CODE)
     interval_features = split_file_into_intervals(temp_testbed, code_feature, 1)
+
     assert len(interval_features) == 2
 
     interval_1 = interval_features[0].intervals[0]

--- a/tests/code_feature_test.py
+++ b/tests/code_feature_test.py
@@ -6,17 +6,13 @@ from mentat.code_feature import CodeFeature, CodeMessageLevel, split_file_into_i
 
 def test_split_file_into_intervals(temp_testbed, mock_session_context):
     with open("file_1.py", "w") as f:
-        f.write(
-            dedent(
-                """\
+        f.write(dedent("""\
             def func_1(x, y):
                 return x + y
             
             def func_2():
                 return 3
-            """
-            )
-        )
+            """))
     code_feature = CodeFeature(Path("file_1.py"), CodeMessageLevel.CODE)
     interval_features = split_file_into_intervals(temp_testbed, code_feature, 1)
 

--- a/tests/code_map_test.py
+++ b/tests/code_map_test.py
@@ -39,4 +39,4 @@ def test_get_code_map(temp_testbed, mock_session_context):
 
 @pytest.mark.parametrize("no_git", [True, False])
 def test_check_ctags_disabled(temp_testbed):
-    assert check_ctags_disabled() == None
+    assert check_ctags_disabled() is None

--- a/tests/code_map_test.py
+++ b/tests/code_map_test.py
@@ -1,0 +1,42 @@
+import pytest
+
+from mentat.code_map import check_ctags_disabled, get_code_map, get_ctags
+
+
+@pytest.mark.parametrize("no_git", [True, False])
+def test_get_ctags(temp_testbed, mock_session_context):
+    echo_py_abs_file_path = temp_testbed.joinpath("scripts/echo.py")
+
+    ctags_with_signatures = get_ctags(echo_py_abs_file_path)
+    assert ctags_with_signatures == {
+        (None, "function", "echo", "(value: Any)", 4),
+        (None, "function", "echo_hardcoded", "()", 8),
+    }
+
+    ctags_without_signatures = get_ctags(echo_py_abs_file_path, exclude_signatures=True)
+    assert ctags_without_signatures == {
+        (None, "function", "echo", None, 4),
+        (None, "function", "echo_hardcoded", None, 8),
+    }
+
+
+@pytest.mark.parametrize("no_git", [True, False])
+def test_get_code_map(temp_testbed, mock_session_context):
+    echo_py_abs_file_path = temp_testbed.joinpath("scripts/echo.py")
+
+    code_map_with_signatures = get_code_map(echo_py_abs_file_path)
+    assert code_map_with_signatures == [
+        "function",
+        "\techo (value: Any)",
+        "\techo_hardcoded ()",
+    ]
+
+    code_map_without_signatures = get_code_map(
+        echo_py_abs_file_path, exclude_signatures=True
+    )
+    assert code_map_without_signatures == ["function", "\techo", "\techo_hardcoded"]
+
+
+@pytest.mark.parametrize("no_git", [True, False])
+def test_check_ctags_disabled(temp_testbed):
+    assert check_ctags_disabled() == None

--- a/tests/code_map_test.py
+++ b/tests/code_map_test.py
@@ -3,7 +3,7 @@ import pytest
 from mentat.code_map import check_ctags_disabled, get_code_map, get_ctags
 
 
-@pytest.mark.parametrize("no_git", [True, False])
+@pytest.mark.no_git_testbed
 def test_get_ctags(temp_testbed, mock_session_context):
     echo_py_abs_file_path = temp_testbed.joinpath("scripts/echo.py")
 
@@ -20,7 +20,7 @@ def test_get_ctags(temp_testbed, mock_session_context):
     }
 
 
-@pytest.mark.parametrize("no_git", [True, False])
+@pytest.mark.no_git_testbed
 def test_get_code_map(temp_testbed, mock_session_context):
     echo_py_abs_file_path = temp_testbed.joinpath("scripts/echo.py")
 
@@ -37,6 +37,6 @@ def test_get_code_map(temp_testbed, mock_session_context):
     assert code_map_without_signatures == ["function", "\techo", "\techo_hardcoded"]
 
 
-@pytest.mark.parametrize("no_git", [True, False])
+@pytest.mark.no_git_testbed
 def test_check_ctags_disabled(temp_testbed):
     assert check_ctags_disabled() is None

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -255,7 +255,7 @@ def temp_testbed(monkeypatch, get_marks, no_git):
     temp_testbed = os.path.join(temp_dir, "testbed")
     os.mkdir(temp_testbed)
 
-    if no_git != True:
+    if no_git is not True:
         # Initialize git repo
         run_git_command(temp_testbed, "init")
 
@@ -269,7 +269,7 @@ def temp_testbed(monkeypatch, get_marks, no_git):
         shutil.copytree("testbed", temp_testbed, dirs_exist_ok=True)
         shutil.copy(".gitignore", temp_testbed)
 
-        if no_git != True:
+        if no_git is not True:
             # Add all files and commit
             run_git_command(temp_testbed, "add", ".")
             run_git_command(temp_testbed, "commit", "-m", "add testbed")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -10,6 +10,7 @@ from uuid import uuid4
 
 import pytest
 import pytest_asyncio
+from ipdb import set_trace
 
 from mentat import config_manager
 from mentat.code_context import CodeContext, CodeContextSettings
@@ -252,7 +253,7 @@ def temp_testbed(monkeypatch, get_marks):
     # necessary to undo chdir before calling rmtree, or it fails on windows
     with monkeypatch.context() as m:
         m.chdir(temp_testbed)
-        yield temp_testbed
+        yield Path(temp_testbed)
 
     shutil.rmtree(temp_dir, onerror=add_permissions)
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -154,7 +154,7 @@ def mock_setup_api_key(mocker):
 # Despite not using any awaits here, this has to be async or there won't be a running event loop
 @pytest_asyncio.fixture()
 async def _mock_session_context(temp_testbed):
-    # TODO make this `None` if there's no git
+    # TODO make this `None` if there's no git (SessionContext needs to allow it)
     git_root = temp_testbed
 
     stream = SessionStream()


### PR DESCRIPTION
This PR removes the need for CodeMap to be run on a file inside of a git repository. 

This is part of a larger effort to allow Mentat Sessions to be started in a non-git directory, which is required by the VSCode extension executable along with just being a very nice feature to have (users can open Mentat anywhere on the filesystem).