### PR TITLE
reset auto tokens default to 0

### DIFF
--- a/mentat/config.py
+++ b/mentat/config.py
@@ -87,7 +87,7 @@ class Config:
         converter=parse_bool,
     )
     auto_tokens: int | None = attr.field(
-        default=None,
+        default=0,
         metadata={
             "description": (
                 "Maximum number of auto-generated tokens to include in the prompt"


### PR DESCRIPTION
After @jakethekoenig refactored the config, default tokens was accidentally turned into None instead of 0; this turns the default back to 0.