### PR TITLE
LLM_API goes to config for model

### DIFF
--- a/mentat/code_feature.py
+++ b/mentat/code_feature.py
@@ -150,7 +150,7 @@ class CodeFeature:
         session_context = SESSION_CONTEXT.get()
         code_file_manager = session_context.code_file_manager
         git_root = session_context.git_root
-        parser = session_context.parser
+        parser = session_context.config.parser
 
         code_message: list[str] = []
 
@@ -208,12 +208,14 @@ class CodeFeature:
             self._code_message = self._get_code_message()
         return self._code_message
 
-    def count_tokens(self, model: str) -> int:
+    def count_tokens(self, model: str | None = None) -> int:
         code_message = self.get_code_message()
-        return count_tokens("\n".join(code_message), model)
+        return count_tokens("\n".join(code_message), model=model)
 
 
-async def count_feature_tokens(features: list[CodeFeature], model: str) -> list[int]:
+async def count_feature_tokens(
+    features: list[CodeFeature], model: str | None = None
+) -> list[int]:
     """Return the number of tokens in each feature."""
     sem = asyncio.Semaphore(10)
 

--- a/mentat/commands.py
+++ b/mentat/commands.py
@@ -371,8 +371,13 @@ class ConfigCommand(Command, command_name="config"):
                             color="yellow",
                         )
                         return
-                    setattr(config, setting, value)
-                    stream.send(f"{setting} set to {value}", color="green")
+                    try:
+                        setattr(config, setting, value)
+                        stream.send(f"{setting} set to {value}", color="green")
+                    except (TypeError, ValueError):
+                        stream.send(
+                            f"Illegal value for {setting}: {value}", color="red"
+                        )
                 else:
                     stream.send("Too many arguments", color="yellow")
             else:

--- a/mentat/config.py
+++ b/mentat/config.py
@@ -157,12 +157,14 @@ class Config:
         return config
 
     def load_namespace(self, args: Namespace) -> None:
-        for field in vars(args):
-            if hasattr(self, field) and getattr(args, field) is not None:
-                try:
-                    setattr(self, field, getattr(args, field))
-                except (ValueError, TypeError) as e:
-                    self.error(f"Warning: Illegal value for {field}: {e}")
+        for field in attr.fields(Config):
+            if field.name in args and field.name != "_errors":
+                value = getattr(args, field.name)
+                if value is not None and value != field.default:
+                    try:
+                        setattr(self, field.name, value)
+                    except (ValueError, TypeError) as e:
+                        self.error(f"Warning: Illegal value for {field}: {e}")
 
     def load_file(self, path: Path) -> None:
         if path.exists():

--- a/mentat/embeddings.py
+++ b/mentat/embeddings.py
@@ -13,7 +13,7 @@ from mentat.llm_api import (
     call_embedding_api,
     count_tokens,
     model_context_size,
-    model_price_per_1000_tokens,
+    price_per_1000_tokens,
 )
 from mentat.session_context import SESSION_CONTEXT
 from mentat.session_input import ask_yes_no
@@ -96,7 +96,7 @@ async def get_feature_similarity_scores(
 
     # Keep things in the same order
     checksums: list[str] = [f.get_checksum() for f in features]
-    tokens: list[int] = await count_feature_tokens(features, EMBEDDING_MODEL)
+    tokens: list[int] = await count_feature_tokens(features, model=EMBEDDING_MODEL)
 
     # Make a checksum:content dict of all items that need to be embedded
     items_to_embed = dict[str, str]()
@@ -117,7 +117,7 @@ async def get_feature_similarity_scores(
             num_prompt_tokens += token
 
     # If it costs more than $1, get confirmation from user.
-    cost = model_price_per_1000_tokens(EMBEDDING_MODEL)
+    cost = price_per_1000_tokens(EMBEDDING_MODEL)
     if cost is None:
         stream.send(
             "Warning: Could not determine cost of embeddings. Continuing anyway.",
@@ -148,8 +148,8 @@ async def get_feature_similarity_scores(
         cost_tracker.display_api_call_stats(
             num_prompt_tokens,
             0,
-            EMBEDDING_MODEL,
             default_timer() - _start_time,
+            model=EMBEDDING_MODEL,
             decimal_places=4,
         )
 

--- a/mentat/session.py
+++ b/mentat/session.py
@@ -16,7 +16,6 @@ from mentat.errors import MentatError, SessionExit
 from mentat.git_handler import get_shared_git_root_for_paths
 from mentat.llm_api import CostTracker, setup_api_key
 from mentat.logging_config import setup_logging
-from mentat.parsers.parser_map import parser_map
 from mentat.session_context import SESSION_CONTEXT, SessionContext
 from mentat.session_input import collect_user_input
 from mentat.session_stream import SessionStream
@@ -45,20 +44,17 @@ class Session:
 
         cost_tracker = CostTracker()
 
-        parser = parser_map[config.format]
-
         code_context = CodeContext(stream, git_root, diff, pr_diff)
 
         code_file_manager = CodeFileManager()
 
-        conversation = Conversation(parser)
+        conversation = Conversation()
 
         session_context = SessionContext(
             stream,
             cost_tracker,
             git_root,
             config,
-            parser,
             code_context,
             code_file_manager,
             conversation,

--- a/mentat/session_context.py
+++ b/mentat/session_context.py
@@ -12,7 +12,6 @@ if TYPE_CHECKING:
     from mentat.config import Config
     from mentat.conversation import Conversation
     from mentat.llm_api import CostTracker
-    from mentat.parsers.parser import Parser
     from mentat.session_stream import SessionStream
 
 SESSION_CONTEXT: ContextVar[SessionContext] = ContextVar("mentat:session_context")
@@ -24,7 +23,6 @@ class SessionContext:
     cost_tracker: CostTracker = attr.field()
     git_root: Path = attr.field()
     config: Config = attr.field()
-    parser: Parser = attr.field()
     code_context: CodeContext = attr.field()
     code_file_manager: CodeFileManager = attr.field()
     conversation: Conversation = attr.field()

--- a/tests/code_context_test.py
+++ b/tests/code_context_test.py
@@ -213,20 +213,14 @@ async def test_get_code_message_cache(mocker, temp_testbed, mock_session_context
         "mentat.code_context.CodeContext._get_code_message"
     )
     mock_get_code_message.return_value = "test1"
-    value1 = await code_context.get_code_message(
-        prompt="", model="gpt-4", max_tokens=1e6
-    )
+    value1 = await code_context.get_code_message(prompt="", max_tokens=1e6)
     mock_get_code_message.return_value = "test2"
-    value2 = await code_context.get_code_message(
-        prompt="", model="gpt-4", max_tokens=1e6
-    )
+    value2 = await code_context.get_code_message(prompt="", max_tokens=1e6)
     assert value1 == value2
 
     # Regenerate if settings change
     mocker.patch.object(Config, "auto_tokens", new=11)
-    value3 = await code_context.get_code_message(
-        prompt="", model="gpt-4", max_tokens=1e6
-    )
+    value3 = await code_context.get_code_message(prompt="", max_tokens=1e6)
     assert value1 != value3
 
     # Regenerate if feature files change
@@ -234,9 +228,7 @@ async def test_get_code_message_cache(mocker, temp_testbed, mock_session_context
     lines = file.read_text().splitlines()
     lines[0] = "something different"
     file.write_text("\n".join(lines))
-    value4 = await code_context.get_code_message(
-        prompt="", model="gpt-4", max_tokens=1e6
-    )
+    value4 = await code_context.get_code_message(prompt="", max_tokens=1e6)
     assert value3 != value4
 
 
@@ -253,9 +245,7 @@ async def test_get_code_message_include(mocker, temp_testbed, mock_session_conte
 
     # If max tokens is less than include_files, return include_files without
     # raising and Exception (that's handled elsewhere)
-    code_message = await code_context.get_code_message(
-        prompt="", model="gpt-4", max_tokens=1e6
-    )
+    code_message = await code_context.get_code_message(prompt="", max_tokens=1e6)
     expected = [
         "Code Files:",
         "",
@@ -304,10 +294,8 @@ async def test_auto_tokens(mocker, temp_testbed, mock_session_context):
 
     async def _count_auto_tokens_where(limit: int) -> int:
         mocker.patch.object(Config, "auto_tokens", new=limit)
-        code_message = await code_context.get_code_message(
-            prompt="", model="gpt-4", max_tokens=1e6
-        )
-        return count_tokens(code_message, "gpt-4")
+        code_message = await code_context.get_code_message(prompt="", max_tokens=1e6)
+        return count_tokens(code_message)
 
     assert await _count_auto_tokens_where(None) == 65  # Cmap w/ signatures
     assert await _count_auto_tokens_where(60) == 57  # Cmap
@@ -377,7 +365,7 @@ async def test_get_code_message_ignore(mocker, temp_testbed, mock_session_contex
         mock_session_context.git_root,
     )
     code_context.set_paths([], [], ["scripts", "**/*.txt"])
-    code_message = await code_context.get_code_message("", "gpt-4", 1e6)
+    code_message = await code_context.get_code_message("", 1e6)
 
     # Iterate through all files in temp_testbed; if they're not in the ignore
     # list, they should be in the code message.

--- a/tests/code_file_manager_test.py
+++ b/tests/code_file_manager_test.py
@@ -23,9 +23,7 @@ async def test_posix_paths(mock_session_context):
         [file_path], []
     )
 
-    code_message = await mock_session_context.code_context.get_code_message(
-        "", mock_session_context.config.model, 1e6
-    )
+    code_message = await mock_session_context.code_context.get_code_message("", 1e6)
     assert dir_name + "/" + file_name in code_message.split("\n")
 
 
@@ -51,7 +49,7 @@ async def test_partial_files(mocker, mock_session_context):
     mock_session_context.code_context.code_map = False
 
     code_message = await mock_session_context.code_context.get_code_message(
-        "", mock_session_context.config.model, max_tokens=1e6
+        "", max_tokens=1e6
     )
     assert code_message == dedent("""\
             Code Files:

--- a/tests/commands_test.py
+++ b/tests/commands_test.py
@@ -192,7 +192,7 @@ async def test_clear_command(
     session.stream.stop()
 
     conversation = SESSION_CONTEXT.get().conversation
-    assert len(conversation.messages) == 1
+    assert len(conversation.get_messages()) == 1
 
 
 @pytest.mark.asyncio

--- a/tests/config_test.py
+++ b/tests/config_test.py
@@ -6,6 +6,7 @@ import pytest
 
 import mentat.config
 from mentat.config import Config, config_file_name
+from mentat.parsers.replacement_parser import ReplacementParser
 
 
 @pytest.mark.asyncio
@@ -31,7 +32,7 @@ async def test_config_creation():
     assert args.model == "model"
     assert args.temperature == 0.2
     assert args.maximum_context == "1"
-    assert args.format is None
+    assert args.parser is None
     assert args.use_embeddings
     assert args.auto_tokens == "2"
 
@@ -46,7 +47,7 @@ async def test_config_creation():
         user_config_file.write(dedent("""\
         {
             "model": "test",
-            "format": "replacement",
+            "parser": "replacement",
             "input_style": [[ "user", "yes" ]]
         }"""))
 
@@ -55,7 +56,7 @@ async def test_config_creation():
     assert config.model == "model"
     assert config.temperature == 0.2
     assert config.maximum_context == 1
-    assert config.format == "replacement"
+    assert type(config.parser) == ReplacementParser
     assert config.use_embeddings
     assert not config.no_code_map
     assert config.auto_tokens == 2
@@ -69,7 +70,7 @@ async def test_invalid_config():
         project_config_file.write(dedent("""\
         {
             "model": "project",
-            "format": "I have a trailing comma",
+            "parser": "I have a trailing comma",
         }"""))
 
     mentat.config.user_config_path = Path(str(config_file_name) + "1")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -17,7 +17,6 @@ from mentat.code_file_manager import CodeFileManager
 from mentat.config import Config, config_file_name
 from mentat.conversation import Conversation
 from mentat.llm_api import CostTracker
-from mentat.session import parser_map
 from mentat.session_context import SESSION_CONTEXT, SessionContext
 from mentat.session_stream import SessionStream, StreamMessage, StreamMessageSource
 from mentat.streaming_printer import StreamingPrinter
@@ -159,7 +158,7 @@ def mock_collect_user_input(mocker):
 @pytest.fixture(scope="function")
 def mock_setup_api_key(mocker):
     mocker.patch("mentat.session.setup_api_key")
-    mocker.patch("mentat.conversation.is_model_available")
+    mocker.patch("mentat.llm_api.is_model_available")
     return
 
 
@@ -181,20 +180,17 @@ async def _mock_session_context(temp_testbed):
 
     config = Config()
 
-    parser = parser_map[config.format]
-
     code_context = CodeContext(stream, git_root)
 
     code_file_manager = CodeFileManager()
 
-    conversation = Conversation(parser)
+    conversation = Conversation()
 
     session_context = SessionContext(
         stream,
         cost_tracker,
         git_root,
         config,
-        parser,
         code_context,
         code_file_manager,
         conversation,

--- a/tests/parser_tests/block_format_error_test.py
+++ b/tests/parser_tests/block_format_error_test.py
@@ -3,12 +3,13 @@ from textwrap import dedent
 import pytest
 
 from mentat.config import Config
+from mentat.parsers.block_parser import BlockParser
 from mentat.session import Session
 
 
 @pytest.fixture(autouse=True)
 def block_parser(mocker):
-    mocker.patch.object(Config, "format", new="block")
+    mocker.patch.object(Config, "parser", new=BlockParser())
 
 
 temp_file_name = "temp.py"

--- a/tests/parser_tests/block_format_test.py
+++ b/tests/parser_tests/block_format_test.py
@@ -11,7 +11,7 @@ from tests.parser_tests.inverse import verify_inverse
 
 @pytest.fixture
 def block_parser(mocker):
-    mocker.patch.object(Config, "format", new="block")
+    mocker.patch.object(Config, "parser", new=BlockParser())
 
 
 @pytest.mark.asyncio

--- a/tests/parser_tests/replacement_format_error_test.py
+++ b/tests/parser_tests/replacement_format_error_test.py
@@ -3,12 +3,13 @@ from textwrap import dedent
 import pytest
 
 from mentat.config import Config
+from mentat.parsers.replacement_parser import ReplacementParser
 from mentat.session import Session
 
 
 @pytest.fixture(autouse=True)
 def replacement_parser(mocker):
-    mocker.patch.object(Config, "format", new="replacement")
+    mocker.patch.object(Config, "parser", new=ReplacementParser())
 
 
 @pytest.mark.asyncio

--- a/tests/parser_tests/replacement_format_test.py
+++ b/tests/parser_tests/replacement_format_test.py
@@ -11,7 +11,7 @@ from tests.parser_tests.inverse import verify_inverse
 
 @pytest.fixture
 def replacement_parser(mocker):
-    mocker.patch.object(Config, "format", new="replacement")
+    mocker.patch.object(Config, "parser", new=ReplacementParser())
 
 
 @pytest.mark.asyncio

--- a/tests/parser_tests/split_diff_format_error_test.py
+++ b/tests/parser_tests/split_diff_format_error_test.py
@@ -3,12 +3,13 @@ from textwrap import dedent
 import pytest
 
 from mentat.config import Config
+from mentat.parsers.split_diff_parser import SplitDiffParser
 from mentat.session import Session
 
 
 @pytest.fixture(autouse=True)
 def split_diff_parser(mocker):
-    mocker.patch.object(Config, "format", new="split-diff")
+    mocker.patch.object(Config, "parser", new=SplitDiffParser())
 
 
 @pytest.mark.asyncio

--- a/tests/parser_tests/split_diff_format_test.py
+++ b/tests/parser_tests/split_diff_format_test.py
@@ -4,12 +4,13 @@ from textwrap import dedent
 import pytest
 
 from mentat.config import Config
+from mentat.parsers.split_diff_parser import SplitDiffParser
 from mentat.session import Session
 
 
 @pytest.fixture(autouse=True)
 def split_diff_parser(mocker):
-    mocker.patch.object(Config, "format", new="split-diff")
+    mocker.patch.object(Config, "parser", new=SplitDiffParser())
 
 
 @pytest.mark.asyncio

--- a/tests/parser_tests/unified_diff_format_error_test.py
+++ b/tests/parser_tests/unified_diff_format_error_test.py
@@ -1,13 +1,14 @@
 from pathlib import Path
 from textwrap import dedent
 
+from mentat.parsers.unified_diff_parser import UnifiedDiffParser
 from mentat.session import Session
 from tests.conftest import Config, pytest
 
 
 @pytest.fixture(autouse=True)
 def unified_diff_parser(mocker):
-    mocker.patch.object(Config, "format", new="unified-diff")
+    mocker.patch.object(Config, "parser", new=UnifiedDiffParser())
 
 
 @pytest.mark.asyncio

--- a/tests/parser_tests/unified_diff_format_test.py
+++ b/tests/parser_tests/unified_diff_format_test.py
@@ -4,12 +4,13 @@ from textwrap import dedent
 import pytest
 
 from mentat.config import Config
+from mentat.parsers.unified_diff_parser import UnifiedDiffParser
 from mentat.session import Session
 
 
 @pytest.fixture(autouse=True)
 def unified_diff_parser(mocker):
-    mocker.patch.object(Config, "format", new="unified-diff")
+    mocker.patch.object(Config, "parser", new=UnifiedDiffParser())
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
* llm_api methods now have model as optional and use the config if unspecified.
* config holds onto parser. Taken out of session_context.
* Bug fix for boolean flags
* New flag to omit system prompt for fine tuned models
* Conversation changed so system prompt and parser can be changed midconversation.