### PR TITLE
Fix initializing mentat with a --diff argument

### DIFF
--- a/mentat/diff_context.py
+++ b/mentat/diff_context.py
@@ -131,7 +131,7 @@ class DiffContext:
                 self.name = "HEAD (last commit)"
                 return
 
-        meta = get_treeish_metadata(target)
+        meta = get_treeish_metadata(git_root, target)
         name += f'{meta["hexsha"][:8]}: {meta["summary"]}'
 
         self.target = target

--- a/mentat/git_handler.py
+++ b/mentat/git_handler.py
@@ -124,10 +124,7 @@ def get_diff_for_file(target: str, path: Path) -> str:
         raise UserError()
 
 
-def get_treeish_metadata(target: str) -> dict[str, str]:
-    session_context = SESSION_CONTEXT.get()
-    git_root = session_context.git_root
-
+def get_treeish_metadata(git_root: Path, target: str) -> dict[str, str]:
     try:
         commit_info = subprocess.check_output(
             ["git", "log", target, "-n", "1", "--pretty=format:%H %s"],


### PR DESCRIPTION
Crashing currently if you run e.g. `mentat --diff HEAD~1`