### PR TITLE
Auto context with llm

### DIFF
--- a/mentat/auto_context.py
+++ b/mentat/auto_context.py
@@ -112,7 +112,6 @@ class LLMFeatureSelector(FeatureSelector, selector_name="llm"):
     ) -> list[CodeFeature]:
         session_context = SESSION_CONTEXT.get()
         config = session_context.config
-        git_root = session_context.git_root
 
         # Preselect as many features as fit in the context window
         model = config.feature_selection_model

--- a/mentat/auto_context.py
+++ b/mentat/auto_context.py
@@ -1,4 +1,5 @@
 import json
+from abc import ABC, abstractmethod
 from pathlib import Path
 from typing import Optional, cast
 
@@ -10,129 +11,166 @@ from mentat.llm_api import count_tokens, model_context_size
 from mentat.prompts.prompts import read_prompt
 from mentat.session_context import SESSION_CONTEXT
 
-"""
-Context selection is similar to the Knapsack Problem: given a set of items (features),
-and a knapsack (context size), choose the best subset of items that fit. In our case we
-can also select which level include. We implement two methods:
 
-- Greedy: add features one-by-one, at the most detailed level possible, until the maximum
-    token limit is reached.
+class FeatureSelector(ABC):
+    """
+    Context selection is similar to the Knapsack Problem: given a set of items (features),
+    and a knapsack (context size), choose the best subset of items that fit. In our case we
+    can also select which level include. We implement two methods:
 
-- LLM: create a full-context of code using the greedy method, then ask the LLM to select
-    only the relevant features. Return its output, up to the token limit.
-"""
+    - Greedy: add features one-by-one, at the most detailed level possible, until the maximum
+        token limit is reached.
 
+    - LLM: create a full-context of code using the greedy method, then ask the LLM to select
+        only the relevant features. Return its output, up to the token limit.
+    """
 
-def select_features_greedy(
-    features: list[CodeFeature],
-    max_tokens: int,
-    model: str = "gpt-4",
-    levels: list[CodeMessageLevel] = [],
-) -> list[CodeFeature]:
-    """Use the greedy method to return a subset of features max_tokens long"""
-    output = list[CodeFeature]()
-    remaining_tokens = max_tokens
-    for feature in features:
-        _levels = list(set(levels) | {feature.level})
-        _levels = sorted(list(_levels), key=lambda v: v.rank)
-        for level in _levels:
-            feature.level = level
-            if feature.count_tokens(model) <= remaining_tokens:
-                output.append(feature)
-                remaining_tokens -= feature.count_tokens(model)
-                break
+    selector_name: str
 
-    return output
+    def __init_subclass__(cls, selector_name: str):
+        cls.selector_name = selector_name
+
+    @abstractmethod
+    async def select(
+        self,
+        features: list[CodeFeature],
+        max_tokens: int,
+        model: str,
+        levels: list[CodeMessageLevel] = [],
+        user_prompt: Optional[str] = None,
+        expected_edits: Optional[list[str]] = None,
+    ) -> list[CodeFeature]:
+        """Select a subset of features that fit in max_tokens"""
+        raise NotImplementedError()
 
 
-feature_selection_prompt_path = Path("feature_selection_prompt.txt")
-feature_selection_prompt_training_path = Path("feature_selection_prompt_training.txt")
-feature_selection_response_buffer = 500
+class GreedyFeatureSelector(FeatureSelector, selector_name="greedy"):
+    async def select(
+        self,
+        features: list[CodeFeature],
+        max_tokens: int,
+        model: str = "gpt-4",
+        levels: list[CodeMessageLevel] = [],
+        user_prompt: Optional[str] = None,
+        expected_edits: Optional[list[str]] = None,
+    ) -> list[CodeFeature]:
+        """Use the greedy method to return a subset of features max_tokens long"""
+        output = list[CodeFeature]()
+        remaining_tokens = max_tokens
+        for feature in features:
+            _levels = list(set(levels) | {feature.level})
+            _levels = sorted(list(_levels), key=lambda v: v.rank)
+            for level in _levels:
+                feature.level = level
+                if feature.count_tokens(model) <= remaining_tokens:
+                    output.append(feature)
+                    remaining_tokens -= feature.count_tokens(model)
+                    break
 
-async def select_features_llm(
-    features: list[CodeFeature],
-    max_tokens: int,
-    model: str = "gpt-4",
-    levels: list[CodeMessageLevel] = [],
-    user_prompt: str = "",
-    expected_edits: Optional[list[str]] = None,  # For benchmarks/training
-) -> list[CodeFeature]:
-    session_context = SESSION_CONTEXT.get()
-    config = session_context.config
-    git_root = session_context.git_root
+        return output
 
-    # Preselect as many features as fit in the context window
-    model = config.feature_selection_model
-    context_size = model_context_size(model)
-    if context_size is None:
-        raise UserError(
-            f"Unknown context size for feature selection model: {config.feature_selection_model}"
-        )
-    system_prompt = read_prompt(feature_selection_prompt_path)
-    training_prompt = read_prompt(feature_selection_prompt_training_path)
-    user_prompt_tokens = count_tokens(user_prompt, model)
-    system_prompt = system_prompt.format(
-        training_prompt=training_prompt if expected_edits else ""
+
+class LLMFeatureSelector(FeatureSelector, selector_name="llm"):
+    feature_selection_prompt_path = Path("feature_selection_prompt.txt")
+    feature_selection_prompt_training_path = Path(
+        "feature_selection_prompt_training.txt"
     )
-    system_prompt_tokens = count_tokens(system_prompt, config.feature_selection_model)
-    preselect_max_tokens = (
-        context_size
-        - system_prompt_tokens
-        - user_prompt_tokens
-        - feature_selection_response_buffer
-    )
-    preselected_features = select_features_greedy(
-        features, preselect_max_tokens, model, levels
-    )
+    feature_selection_response_buffer = 500
 
-    # Ask the model to return only relevant features
-    content_message = [
-        "User Query:",
-        user_prompt,
-        "",
-        "Code Files:",
-    ]
-    for feature in preselected_features:
-        content_message += feature.get_code_message()
-    messages = [
-        {"role": "system", "content": system_prompt},
-        {"role": "system", "content": "\n".join(content_message)},
-    ]
-    response = await openai.ChatCompletion.acreate(  # type: ignore
-        model=model,
-        messages=messages,
-        temperature=config.temperature,
-    )
+    async def select(
+        self,
+        features: list[CodeFeature],
+        max_tokens: int,
+        model: str = "gpt-4",
+        levels: list[CodeMessageLevel] = [],
+        user_prompt: Optional[str] = None,
+        expected_edits: Optional[list[str]] = None,
+    ) -> list[CodeFeature]:
+        session_context = SESSION_CONTEXT.get()
+        config = session_context.config
+        git_root = session_context.git_root
 
-    # Create output features from the response
-    message = cast(str, response["choices"][0]["message"]["content"])  # type: ignore
-    try:
-        selected_refs = json.loads(message)
-    except json.JSONDecodeError:
-        raise ValueError(f"The response is not valid json: {message}")
-    postselected_features = [CodeFeature(git_root / p) for p in selected_refs]
-    for out_feat in postselected_features:
-        # Match with corresponding inputs
-        matching_inputs = [
-            in_feat
-            for in_feat in features
-            if in_feat.path == out_feat.path
-            and any(
-                i_in.intersects(i_out)
-                for i_in in in_feat.intervals
-                for i_out in out_feat.intervals
+        # Preselect as many features as fit in the context window
+        model = config.feature_selection_model
+        context_size = model_context_size(model)
+        if context_size is None:
+            raise UserError(
+                "Unknown context size for feature selection model: "
+                f"{config.feature_selection_model}"
             )
-        ]
-        if len(matching_inputs) == 0:
-            raise ValueError(f"No input feature found for llm-selected {out_feat}")
-        # Copy metadata
-        out_feat.user_included = any(f.user_included for f in matching_inputs)
-        diff = any(f.diff for f in matching_inputs)
-        name = any(f.name for f in matching_inputs)
-        if diff:
-            out_feat.diff = next(f.diff for f in matching_inputs if f.diff)
-        if name:
-            out_feat.name = next(f.name for f in matching_inputs if f.name)
+        system_prompt = read_prompt(self.feature_selection_prompt_path)
+        training_prompt = read_prompt(self.feature_selection_prompt_training_path)
+        if user_prompt is None:
+            user_prompt = ""
+        user_prompt_tokens = count_tokens(user_prompt, model)
+        system_prompt = system_prompt.format(
+            training_prompt=training_prompt if expected_edits else ""
+        )
+        system_prompt_tokens = count_tokens(
+            system_prompt, config.feature_selection_model
+        )
+        preselect_max_tokens = (
+            context_size
+            - system_prompt_tokens
+            - user_prompt_tokens
+            - self.feature_selection_response_buffer
+        )
+        greedy_selector = GreedyFeatureSelector()
+        preselected_features = await greedy_selector.select(
+            features, preselect_max_tokens, model, levels
+        )
 
-    # Greedy again to enforce max_tokens
-    return select_features_greedy(postselected_features, max_tokens, model)
+        # Ask the model to return only relevant features
+        content_message = [
+            "User Query:",
+            user_prompt,
+            "",
+            "Code Files:",
+        ]
+        for feature in preselected_features:
+            content_message += feature.get_code_message()
+        messages = [
+            {"role": "system", "content": system_prompt},
+            {"role": "system", "content": "\n".join(content_message)},
+        ]
+        response = await openai.ChatCompletion.acreate(  # type: ignore
+            model=model,
+            messages=messages,
+            temperature=config.temperature,
+        )
+
+        # Create output features from the response
+        message = cast(str, response["choices"][0]["message"]["content"])  # type: ignore
+        try:
+            selected_refs = json.loads(message)
+        except json.JSONDecodeError:
+            raise ValueError(f"The response is not valid json: {message}")
+        postselected_features = [CodeFeature(git_root / p) for p in selected_refs]
+        for out_feat in postselected_features:
+            # Match with corresponding inputs
+            matching_inputs = [
+                in_feat
+                for in_feat in features
+                if in_feat.path == out_feat.path
+                and in_feat.interval.intersects(out_feat.interval)
+            ]
+            if len(matching_inputs) == 0:
+                raise ValueError(f"No input feature found for llm-selected {out_feat}")
+            # Copy metadata
+            out_feat.user_included = any(f.user_included for f in matching_inputs)
+            diff = any(f.diff for f in matching_inputs)
+            name = any(f.name for f in matching_inputs)
+            if diff:
+                out_feat.diff = next(f.diff for f in matching_inputs if f.diff)
+            if name:
+                out_feat.name = next(f.name for f in matching_inputs if f.name)
+
+        # Greedy again to enforce max_tokens
+        return await greedy_selector.select(postselected_features, max_tokens, model)
+
+
+def get_feature_selector(use_llm: bool) -> FeatureSelector:
+    if use_llm:
+        return LLMFeatureSelector()
+    else:
+        return GreedyFeatureSelector()

--- a/mentat/auto_context.py
+++ b/mentat/auto_context.py
@@ -1,0 +1,163 @@
+"""
+This module solves a variation of the Knapsack Problem, selecting code features
+while adhering to a maximum token limit. There are two methods implemented, each
+of which returns a subset of the input features:
+
+- `select_features_greedy`: Add features one-by-one, at the most detailed level
+   possible, until the maximum token limit is reached.
+   
+- `select_features_llm`: Create a full-context of code using the greedy method,
+   then ask the LLM to select only the relevant features.
+
+"""
+import json
+from textwrap import dedent
+from typing import Optional, cast
+
+import openai
+
+from mentat.code_feature import CodeFeature, CodeMessageLevel
+from mentat.llm_api import count_tokens
+from mentat.session_context import SESSION_CONTEXT
+
+
+def select_features_greedy(
+    features: list[CodeFeature],
+    max_tokens: int,
+    model: str = "gpt-4",
+    levels: list[CodeMessageLevel] = [],
+) -> list[CodeFeature]:
+    """Use the greedy method to return a subset of features max_tokens long
+
+    Args:
+        features: the list of code features to select from
+        max_tokens: the maximum number of tokens to return
+        model: the model to use for token counting
+        no_code_map: whether to exclude features with the 'cmap' level
+        levels: additional levels to consider
+    """
+    output = list[CodeFeature]()
+    remaining_tokens = max_tokens
+    for feature in features:
+        _levels = list(set(levels) | {feature.level})
+        _levels = sorted(list(_levels), key=lambda l: l.rank)
+        for level in _levels:
+            feature.level = level
+            if feature.count_tokens(model) <= remaining_tokens:
+                output.append(feature)
+                remaining_tokens -= feature.count_tokens(model)
+                break
+
+    return output
+
+
+feature_selection_model = "gpt-4"
+feature_selection_max_tokens = 8192
+feature_selection_temperature = 0.5
+feature_selection_response_buffer = 500  # Tokens
+
+
+def get_feature_selection_prompt(expected_edits: Optional[list[str]] = None) -> str:
+    output = dedent("""\
+        You are part of an automated system for making synthetic data. \
+        Below you will see the line 'User Query:', followed by a user query, followed by the line 'Code Files:' and then a pre-selected subset of a codebase. \
+        Your job is to select portions of the code which are relevant to answering that query. \
+        The process after you will read the lines code you select and respond to the query. \
+        {{training_prompt}}
+        Each item you see from the codebase will include a relative path and line numbers. \
+        Identify lines of code which are relevant to the query. \
+        Return a json-serializable list of relevant items following the same format you receive: <rel_path>:<start_line>-<end_line>. \
+        It's important to include lines which would be edited in order to generate the answer \
+        as well as lines which are required to understand the context. \
+        It's equally important to exclude irrelevant code, as it has a negative impact on the system performance and cost. \
+        For example: if a question requires creating a new method related to a class, and the method uses an attribute of that \
+        class, include the location for the edit as well as where the attribute is defined. If a typing system is used, include \
+        the type definition as well, and the location of the expected import. \
+        Make sure your response is valid json, for example: \
+        ["path/to/file1.py:1-10", "path/to/file2.py:11-20"]
+    """)
+    if expected_edits:
+        training_prompt = ""  # TODO: add instructions
+        training_prompt += "\n".join(expected_edits)
+        output.replace("{{training_prompt}}", training_prompt)
+    else:
+        output.replace("{{training_prompt}}", "")
+    return output
+
+
+async def select_features_llm(
+    features: list[CodeFeature],
+    max_tokens: int,
+    model: str = "gpt-4",
+    levels: list[CodeMessageLevel] = [],
+    user_prompt: str = "",
+    expected_edits: Optional[list[str]] = None,  # For benchmarks/training
+) -> list[CodeFeature]:
+    session_context = SESSION_CONTEXT.get()
+    git_root = session_context.git_root
+
+    # Preselect as many features as fit in the context window
+    user_prompt_tokens = count_tokens(user_prompt, model)
+    system_prompt = get_feature_selection_prompt(expected_edits)
+    system_prompt_tokens = count_tokens(system_prompt, feature_selection_model)
+    preselect_max_tokens = (
+        feature_selection_max_tokens
+        - system_prompt_tokens
+        - user_prompt_tokens
+        - feature_selection_response_buffer
+    )
+    preselected_features = select_features_greedy(
+        features, preselect_max_tokens, feature_selection_model, levels
+    )
+
+    # Ask the model to return only relevant features
+    content_message = [
+        f"User Query:",
+        user_prompt,
+        "",
+        "Code Files:",
+    ]
+    for feature in preselected_features:
+        content_message += feature.get_code_message()
+    messages = [
+        {"role": "system", "content": system_prompt},
+        {"role": "system", "content": "\n".join(content_message)},
+    ]
+    response = await openai.ChatCompletion.acreate(  # type: ignore
+        model=model,
+        messages=messages,
+        temperature=feature_selection_temperature,
+    )
+
+    # Create output features from the response
+    message = cast(str, response["choices"][0]["message"]["content"])  # type: ignore
+    try:
+        selected_refs = json.loads(message)
+    except json.JSONDecodeError:
+        raise ValueError(f"The response is not valid json: {message}")
+    postselected_features = [CodeFeature(git_root / p) for p in selected_refs]
+    for out_feat in postselected_features:
+        # Match with corresponding inputs
+        matching_inputs = [
+            in_feat
+            for in_feat in features
+            if in_feat.path == out_feat.path
+            and any(
+                i_in.intersects(i_out)
+                for i_in in in_feat.intervals
+                for i_out in out_feat.intervals
+            )
+        ]
+        if len(matching_inputs) == 0:
+            raise ValueError(f"No input feature found for llm-selected {out_feat}")
+        # Copy metadata
+        out_feat.user_included = any(f.user_included for f in matching_inputs)
+        diff = any(f.diff for f in matching_inputs)
+        name = any(f.name for f in matching_inputs)
+        if diff:
+            out_feat.diff = next(f.diff for f in matching_inputs if f.diff)
+        if name:
+            out_feat.name = next(f.name for f in matching_inputs if f.name)
+
+    # Greedy again to enforce max_tokens
+    return select_features_greedy(postselected_features, max_tokens, model)

--- a/mentat/auto_context.py
+++ b/mentat/auto_context.py
@@ -1,15 +1,3 @@
-"""
-This module solves a variation of the Knapsack Problem, selecting code features
-while adhering to a maximum token limit. There are two methods implemented, each
-of which returns a subset of the input features:
-
-- `select_features_greedy`: Add features one-by-one, at the most detailed level
-   possible, until the maximum token limit is reached.
-   
-- `select_features_llm`: Create a full-context of code using the greedy method,
-   then ask the LLM to select only the relevant features.
-
-"""
 import json
 from textwrap import dedent
 from typing import Optional, cast
@@ -20,6 +8,18 @@ from mentat.code_feature import CodeFeature, CodeMessageLevel
 from mentat.llm_api import count_tokens
 from mentat.session_context import SESSION_CONTEXT
 
+"""
+Context selection is similar to the Knapsack Problem: given a set of items (features),
+and a knapsack (context size), choose the best subset of items that fit. In our case we
+can also select which level include. We implement two methods:
+
+- Greedy: add features one-by-one, at the most detailed level possible, until the maximum
+    token limit is reached.
+
+- LLM: create a full-context of code using the greedy method, then ask the LLM to select
+    only the relevant features. Return its output, up to the token limit.
+"""
+
 
 def select_features_greedy(
     features: list[CodeFeature],
@@ -27,15 +27,7 @@ def select_features_greedy(
     model: str = "gpt-4",
     levels: list[CodeMessageLevel] = [],
 ) -> list[CodeFeature]:
-    """Use the greedy method to return a subset of features max_tokens long
-
-    Args:
-        features: the list of code features to select from
-        max_tokens: the maximum number of tokens to return
-        model: the model to use for token counting
-        no_code_map: whether to exclude features with the 'cmap' level
-        levels: additional levels to consider
-    """
+    """Use the greedy method to return a subset of features max_tokens long"""
     output = list[CodeFeature]()
     remaining_tokens = max_tokens
     for feature in features:
@@ -54,35 +46,28 @@ def select_features_greedy(
 feature_selection_model = "gpt-4"
 feature_selection_max_tokens = 8192
 feature_selection_temperature = 0.5
-feature_selection_response_buffer = 500  # Tokens
-
-
-def get_feature_selection_prompt(expected_edits: Optional[list[str]] = None) -> str:
-    output = dedent("""\
-        You are part of an automated system for making synthetic data. \
-        Below you will see the line 'User Query:', followed by a user query, followed by the line 'Code Files:' and then a pre-selected subset of a codebase. \
-        Your job is to select portions of the code which are relevant to answering that query. \
-        The process after you will read the lines code you select and respond to the query. \
-        {{training_prompt}}
-        Each item you see from the codebase will include a relative path and line numbers. \
-        Identify lines of code which are relevant to the query. \
-        Return a json-serializable list of relevant items following the same format you receive: <rel_path>:<start_line>-<end_line>. \
-        It's important to include lines which would be edited in order to generate the answer \
-        as well as lines which are required to understand the context. \
-        It's equally important to exclude irrelevant code, as it has a negative impact on the system performance and cost. \
-        For example: if a question requires creating a new method related to a class, and the method uses an attribute of that \
-        class, include the location for the edit as well as where the attribute is defined. If a typing system is used, include \
-        the type definition as well, and the location of the expected import. \
-        Make sure your response is valid json, for example: \
-        ["path/to/file1.py:1-10", "path/to/file2.py:11-20"]
+feature_selection_response_buffer = 500
+feature_selection_prompt = dedent("""\
+    You are part of an automated coding system. 
+    Below you will see the line 'User Query:', followed by a user query, followed by the line 'Code Files:' and then a pre-selected subset of a codebase.
+    Your job is to select portions of the code which are relevant to answering that query.
+    The process after you will read the lines code you select, and then return a plaintext plan of action and a list of Code Edits.
+    {{training_prompt}}
+    Each item in the Code Files below will include a relative path and line numbers.
+    Identify lines of code which are relevant to the query.
+    Return a json-serializable list of relevant items following the same format you receive: <rel_path>:<start_line>-<end_line>,<start_line>-<end_line>.
+    It's important to include lines which would be edited in order to generate the answer as well as lines which are required to understand the context.
+    It's equally important to exclude irrelevant code, as it has a negative impact on the system performance and cost.
+    For example: if a question requires creating a new method related to a class, and the method uses an attribute of that
+    class, include the location for the edit as well as where the attribute is defined. If a typing system is used, include
+    the type definition as well, and the location of the expected import.
+    Make sure your response is valid json, for example:
+    ["path/to/file1.py:1-10,53-60", "path/to/file2.py:10-20"]
     """)
-    if expected_edits:
-        training_prompt = ""  # TODO: add instructions
-        training_prompt += "\n".join(expected_edits)
-        output.replace("{{training_prompt}}", training_prompt)
-    else:
-        output.replace("{{training_prompt}}", "")
-    return output
+training_prompt = (
+    "You are currently being used to generate benchmarking data, so you'll be shown"
+    " those Code Edits as well in order to maximize your performance."
+)
 
 
 async def select_features_llm(
@@ -98,7 +83,9 @@ async def select_features_llm(
 
     # Preselect as many features as fit in the context window
     user_prompt_tokens = count_tokens(user_prompt, model)
-    system_prompt = get_feature_selection_prompt(expected_edits)
+    system_prompt = feature_selection_prompt.format(
+        training_prompt=training_prompt if expected_edits else ""
+    )
     system_prompt_tokens = count_tokens(system_prompt, feature_selection_model)
     preselect_max_tokens = (
         feature_selection_max_tokens
@@ -112,7 +99,7 @@ async def select_features_llm(
 
     # Ask the model to return only relevant features
     content_message = [
-        f"User Query:",
+        "User Query:",
         user_prompt,
         "",
         "Code Files:",

--- a/mentat/auto_context.py
+++ b/mentat/auto_context.py
@@ -40,7 +40,7 @@ def select_features_greedy(
     remaining_tokens = max_tokens
     for feature in features:
         _levels = list(set(levels) | {feature.level})
-        _levels = sorted(list(_levels), key=lambda l: l.rank)
+        _levels = sorted(list(_levels), key=lambda v: v.rank)
         for level in _levels:
             feature.level = level
             if feature.count_tokens(model) <= remaining_tokens:

--- a/mentat/code_context.py
+++ b/mentat/code_context.py
@@ -339,15 +339,11 @@ class CodeContext:
                     prompt,
                     expected_edits,
                 )
-                self.features = _merge_features(features, auto_features)
             else:
-                auto_features = [
-                    f for f in auto_features if f.path not in self.include_files
-                ]
                 auto_features = select_features_greedy(
                     auto_features, auto_tokens, model, auto_levels
                 )
-                self.features = features + auto_features
+            self.features = _merge_features(features, auto_features)
 
         for f in self.features:
             # TODO: Join features of same file with ellipses and a single fname

--- a/mentat/code_context.py
+++ b/mentat/code_context.py
@@ -5,6 +5,7 @@ from pathlib import Path
 from textwrap import dedent
 from typing import Optional
 
+from mentat.auto_context import select_features_greedy, select_features_llm
 from mentat.code_feature import (
     CodeFeature,
     CodeMessageLevel,
@@ -23,6 +24,7 @@ from mentat.include_files import (
     print_invalid_path,
     print_path_tree,
 )
+from mentat.interval import Interval
 from mentat.llm_api import count_tokens
 from mentat.session_context import SESSION_CONTEXT
 from mentat.session_stream import SessionStream
@@ -74,7 +76,47 @@ def _get_all_features(
             )
             all_features.append(_feature)
 
-    return all_features
+    return sorted(all_features, key=lambda f: f.path.relative_to(git_root))
+
+
+def _merge_features(a: list[CodeFeature], b: list[CodeFeature]) -> list[CodeFeature]:
+    output = list[CodeFeature]()
+    for feature in a + b:
+        matching = [f for f in output if f.path == feature.path]
+        intersects = (
+            False
+            if not matching
+            else any(
+                i_feat.intersects(i_match)
+                for i_feat in feature.intervals
+                for i_match in matching[0].intervals
+            )
+        )
+        if not matching or not intersects:
+            output.append(feature)
+            continue
+
+        # Replace matching feature's intervals with a single interval covering
+        # the entire range of both features.
+        # TODO: Our features currently support multiple intervals so this step
+        # could add additional lines, but it would be better to make all features
+        # single-interval than build-out this.
+        feature_start = min(feature.intervals, key=lambda i: i.start)
+        feature_end = max(feature.intervals, key=lambda i: i.end)
+        matching_start = min(matching[0].intervals, key=lambda i: i.start)
+        matching_end = max(matching[0].intervals, key=lambda i: i.end)
+        matching[0].intervals = [
+            Interval(
+                min(feature_start.start, matching_start.start),
+                max(feature_end.end, matching_end.end),
+            )
+        ]
+        if feature.diff and not matching[0].diff:
+            matching[0].diff = feature.diff
+        if feature.user_included and not matching[0].user_included:
+            matching[0].user_included = feature.user_included
+
+    return output
 
 
 class CodeContext:
@@ -203,6 +245,7 @@ class CodeContext:
             "code_map": self.code_map,
             "auto_tokens": config.auto_tokens,
             "use_embeddings": config.use_embeddings,
+            "use_llm": self.use_llm,
             "diff": self.diff,
             "pr_diff": self.pr_diff,
             "max_tokens": max_tokens,
@@ -216,24 +259,32 @@ class CodeContext:
         prompt: str,
         model: str,
         max_tokens: int,
+        expected_edits: Optional[list[str]] = None,  # for training/benchmarking
     ) -> str:
         code_message_checksum = self._get_code_message_checksum(max_tokens)
         if (
             self._code_message is None
             or code_message_checksum != self._code_message_checksum
         ):
-            self._code_message = await self._get_code_message(prompt, model, max_tokens)
+            self._code_message = await self._get_code_message(
+                prompt, model, max_tokens, expected_edits
+            )
             self._code_message_checksum = self._get_code_message_checksum(max_tokens)
         return self._code_message
+
+    use_llm: bool = False
+    auto_threshold: float = 0.0
 
     async def _get_code_message(
         self,
         prompt: str,
         model: str,
         max_tokens: int,
+        expected_edits: Optional[list[str]] = None,
     ) -> str:
         session_context = SESSION_CONTEXT.get()
         config = session_context.config
+        git_root = session_context.git_root
 
         code_message = list[str]()
 
@@ -257,11 +308,49 @@ class CodeContext:
             self.features = features
         else:
             auto_tokens = _max_auto if _max_user is None else min(_max_auto, _max_user)
-            self.features = await self._get_auto_features(
-                prompt, model, features, auto_tokens
-            )
+            auto_levels = sorted(CodeMessageLevel, key=lambda v: v.rank)
+            if not self.code_map:
+                auto_levels = [v for v in auto_levels if "cmap" not in v.key]
+            if not self.use_llm:
+                auto_levels = [
+                    v for v in auto_levels if v.key not in ("code", "interval")
+                ]
+
+            if prompt and config.use_embeddings:
+                candidate_features = await self.search(prompt, level=auto_levels[0])
+                candidate_features = [
+                    f[0] for f in candidate_features
+                ]  # Drop scores, rely on order
+            else:
+                candidate_features = _get_all_features(
+                    git_root,
+                    self.include_files,
+                    self.ignore_files,
+                    self.diff_context,
+                    self.code_map,
+                    auto_levels[0],
+                )
+
+            if self.use_llm:
+                auto_features = await select_features_llm(
+                    candidate_features,
+                    auto_tokens,
+                    model,
+                    auto_levels,
+                    prompt,
+                    expected_edits,
+                )
+            else:
+                candidate_features = [
+                    f for f in candidate_features if f.path not in self.include_files
+                ]
+                auto_features = select_features_greedy(
+                    candidate_features, auto_tokens, model, auto_levels
+                )
+            self.features = _merge_features(features, auto_features)
 
         for f in self.features:
+            # TODO: Join features of same file with ellipses and a single fname
             code_message += f.get_code_message()
         return "\n".join(code_message)
 
@@ -287,84 +376,6 @@ class CodeContext:
             return os.path.relpath(f.path, git_root)
 
         return sorted(include_features, key=_feature_relative_path)
-
-    async def _get_auto_features(
-        self,
-        prompt: str,
-        model: str,
-        include_features: list[CodeFeature],
-        max_tokens: int,
-    ) -> list[CodeFeature]:
-        """Return a list of features that fit within the max_tokens limit
-
-        - user_features: excluded from auto-features process, added to return list
-        """
-        session_context = SESSION_CONTEXT.get()
-        config = session_context.config
-        git_root = session_context.git_root
-
-        # Find the first (longest) level that fits
-        include_features_tokens = sum(
-            await count_feature_tokens(include_features, model)
-        )
-        max_auto_tokens = max_tokens - include_features_tokens
-        all_features = include_features.copy()
-        levels = [CodeMessageLevel.FILE_NAME]
-        if not config.no_code_map:
-            levels = [CodeMessageLevel.CMAP_FULL, CodeMessageLevel.CMAP] + levels
-        for level in levels:
-            level_features = _get_all_features(
-                git_root,
-                self.include_files,
-                self.ignore_files,
-                self.diff_context,
-                self.code_map,
-                level,
-            )
-            level_features = [
-                f for f in level_features if f.path not in self.include_files
-            ]
-            level_length = sum(await count_feature_tokens(level_features, model))
-            if level_length < max_auto_tokens:
-                all_features += level_features
-                break
-
-        # Sort by relative path
-        def _feature_relative_path(f: CodeFeature) -> str:
-            return os.path.relpath(f.path, git_root)
-
-        all_features = sorted(all_features, key=_feature_relative_path)
-
-        # If there's room, convert cmap features to code features (full text)
-        # starting with the highest-scoring.
-        cmap_features_tokens = sum(await count_feature_tokens(all_features, model))
-        max_sim_tokens = max_tokens - cmap_features_tokens
-        if config.auto_tokens is not None:
-            max_sim_tokens = min(max_sim_tokens, config.auto_tokens)
-
-        if config.use_embeddings and max_sim_tokens > 0 and prompt != "":
-            sim_tokens = 0
-
-            # Get embedding-similarity scores for all files
-            all_code_features_sorted = await self.search(
-                query=prompt,
-                level=CodeMessageLevel.CODE,
-                # TODO: Change to INTERVAL after update get_code_message
-            )
-            for code_feature, _ in all_code_features_sorted:
-                abs_path = git_root / code_feature.path
-                # Calculate the total change in length
-                i_cmap, cmap_feature = next(
-                    (i, f) for i, f in enumerate(all_features) if f.path == abs_path
-                )
-                recovered_tokens = cmap_feature.count_tokens(model)
-                new_tokens = code_feature.count_tokens(model)
-                forecast = max_sim_tokens - sim_tokens + recovered_tokens - new_tokens
-                if forecast > 0:
-                    sim_tokens = sim_tokens + new_tokens - recovered_tokens
-                    all_features[i_cmap] = code_feature
-
-        return sorted(all_features, key=_feature_relative_path)
 
     def include_file(self, path: Path):
         paths, invalid_paths = get_include_files([path], [])

--- a/mentat/code_context.py
+++ b/mentat/code_context.py
@@ -307,12 +307,12 @@ class CodeContext:
             self.features = features
         else:
             auto_tokens = _max_auto if _max_user is None else min(_max_auto, _max_user)
-            auto_levels = sorted(CodeMessageLevel, key=lambda l: l.rank)
+            auto_levels = sorted(CodeMessageLevel, key=lambda v: v.rank)
             if not self.code_map:
-                auto_levels = [l for l in auto_levels if "cmap" not in l.key]
+                auto_levels = [v for v in auto_levels if "cmap" not in v.key]
             if not self.use_llm:
                 auto_levels = [
-                    l for l in auto_levels if l.key not in ("code", "interval")
+                    v for v in auto_levels if v.key not in ("code", "interval")
                 ]
 
             if prompt and config.use_embeddings:

--- a/mentat/code_context.py
+++ b/mentat/code_context.py
@@ -5,7 +5,6 @@ from pathlib import Path
 from textwrap import dedent
 from typing import Optional
 
-from mentat.auto_context import select_features_greedy, select_features_llm
 from mentat.code_feature import (
     CodeFeature,
     CodeMessageLevel,
@@ -24,7 +23,6 @@ from mentat.include_files import (
     print_invalid_path,
     print_path_tree,
 )
-from mentat.interval import Interval
 from mentat.llm_api import count_tokens
 from mentat.session_context import SESSION_CONTEXT
 from mentat.session_stream import SessionStream
@@ -77,46 +75,6 @@ def _get_all_features(
             all_features.append(_feature)
 
     return all_features
-
-
-def _merge_features(a: list[CodeFeature], b: list[CodeFeature]) -> list[CodeFeature]:
-    output = list[CodeFeature]()
-    for feature in a + b:
-        matching = [f for f in output if f.path == feature.path]
-        intersects = (
-            False
-            if not matching
-            else any(
-                i_feat.intersects(i_match)
-                for i_feat in feature.intervals
-                for i_match in matching[0].intervals
-            )
-        )
-        if not matching or not intersects:
-            output.append(feature)
-            continue
-
-        # Replace matching feature's intervals with a single interval covering
-        # the entire range of both features.
-        # TODO: Our features currently support multiple intervals so this step
-        # could add additional lines, but it would be better to make all features
-        # single-interval than build-out this.
-        feature_start = min(feature.intervals, key=lambda i: i.start)
-        feature_end = max(feature.intervals, key=lambda i: i.end)
-        matching_start = min(matching[0].intervals, key=lambda i: i.start)
-        matching_end = max(matching[0].intervals, key=lambda i: i.end)
-        matching[0].intervals = [
-            Interval(
-                min(feature_start.start, matching_start.start),
-                max(feature_end.end, matching_end.end),
-            )
-        ]
-        if feature.diff and not matching[0].diff:
-            matching[0].diff = feature.diff
-        if feature.user_included and not matching[0].user_included:
-            matching[0].user_included = feature.user_included
-
-    return output
 
 
 class CodeContext:
@@ -258,32 +216,24 @@ class CodeContext:
         prompt: str,
         model: str,
         max_tokens: int,
-        expected_edits: Optional[list[str]] = None,  # for training/benchmarking
     ) -> str:
         code_message_checksum = self._get_code_message_checksum(max_tokens)
         if (
             self._code_message is None
             or code_message_checksum != self._code_message_checksum
         ):
-            self._code_message = await self._get_code_message(
-                prompt, model, max_tokens, expected_edits
-            )
+            self._code_message = await self._get_code_message(prompt, model, max_tokens)
             self._code_message_checksum = self._get_code_message_checksum(max_tokens)
         return self._code_message
-
-    use_llm: bool = False
-    auto_threshold: float = 0.0
 
     async def _get_code_message(
         self,
         prompt: str,
         model: str,
         max_tokens: int,
-        expected_edits: Optional[list[str]] = None,
     ) -> str:
         session_context = SESSION_CONTEXT.get()
         config = session_context.config
-        git_root = session_context.git_root
 
         code_message = list[str]()
 
@@ -307,46 +257,11 @@ class CodeContext:
             self.features = features
         else:
             auto_tokens = _max_auto if _max_user is None else min(_max_auto, _max_user)
-            auto_levels = sorted(CodeMessageLevel, key=lambda v: v.rank)
-            if not self.code_map:
-                auto_levels = [v for v in auto_levels if "cmap" not in v.key]
-            if not self.use_llm:
-                auto_levels = [
-                    v for v in auto_levels if v.key not in ("code", "interval")
-                ]
-
-            if prompt and config.use_embeddings:
-                auto_features = await self.search(prompt, level=auto_levels[0])
-                auto_features = [
-                    f[0] for f in auto_features
-                ]  # Drop scores, rely on order
-            else:
-                auto_features = _get_all_features(
-                    git_root,
-                    self.include_files,
-                    self.ignore_files,
-                    self.diff_context,
-                    self.code_map,
-                    auto_levels[0],
-                )
-
-            if self.use_llm:
-                auto_features = await select_features_llm(
-                    auto_features,
-                    auto_tokens,
-                    model,
-                    auto_levels,
-                    prompt,
-                    expected_edits,
-                )
-            else:
-                auto_features = select_features_greedy(
-                    auto_features, auto_tokens, model, auto_levels
-                )
-            self.features = _merge_features(features, auto_features)
+            self.features = await self._get_auto_features(
+                prompt, model, features, auto_tokens
+            )
 
         for f in self.features:
-            # TODO: Join features of same file with ellipses and a single fname
             code_message += f.get_code_message()
         return "\n".join(code_message)
 
@@ -372,6 +287,84 @@ class CodeContext:
             return os.path.relpath(f.path, git_root)
 
         return sorted(include_features, key=_feature_relative_path)
+
+    async def _get_auto_features(
+        self,
+        prompt: str,
+        model: str,
+        include_features: list[CodeFeature],
+        max_tokens: int,
+    ) -> list[CodeFeature]:
+        """Return a list of features that fit within the max_tokens limit
+
+        - user_features: excluded from auto-features process, added to return list
+        """
+        session_context = SESSION_CONTEXT.get()
+        config = session_context.config
+        git_root = session_context.git_root
+
+        # Find the first (longest) level that fits
+        include_features_tokens = sum(
+            await count_feature_tokens(include_features, model)
+        )
+        max_auto_tokens = max_tokens - include_features_tokens
+        all_features = include_features.copy()
+        levels = [CodeMessageLevel.FILE_NAME]
+        if not config.no_code_map:
+            levels = [CodeMessageLevel.CMAP_FULL, CodeMessageLevel.CMAP] + levels
+        for level in levels:
+            level_features = _get_all_features(
+                git_root,
+                self.include_files,
+                self.ignore_files,
+                self.diff_context,
+                self.code_map,
+                level,
+            )
+            level_features = [
+                f for f in level_features if f.path not in self.include_files
+            ]
+            level_length = sum(await count_feature_tokens(level_features, model))
+            if level_length < max_auto_tokens:
+                all_features += level_features
+                break
+
+        # Sort by relative path
+        def _feature_relative_path(f: CodeFeature) -> str:
+            return os.path.relpath(f.path, git_root)
+
+        all_features = sorted(all_features, key=_feature_relative_path)
+
+        # If there's room, convert cmap features to code features (full text)
+        # starting with the highest-scoring.
+        cmap_features_tokens = sum(await count_feature_tokens(all_features, model))
+        max_sim_tokens = max_tokens - cmap_features_tokens
+        if config.auto_tokens is not None:
+            max_sim_tokens = min(max_sim_tokens, config.auto_tokens)
+
+        if config.use_embeddings and max_sim_tokens > 0 and prompt != "":
+            sim_tokens = 0
+
+            # Get embedding-similarity scores for all files
+            all_code_features_sorted = await self.search(
+                query=prompt,
+                level=CodeMessageLevel.CODE,
+                # TODO: Change to INTERVAL after update get_code_message
+            )
+            for code_feature, _ in all_code_features_sorted:
+                abs_path = git_root / code_feature.path
+                # Calculate the total change in length
+                i_cmap, cmap_feature = next(
+                    (i, f) for i, f in enumerate(all_features) if f.path == abs_path
+                )
+                recovered_tokens = cmap_feature.count_tokens(model)
+                new_tokens = code_feature.count_tokens(model)
+                forecast = max_sim_tokens - sim_tokens + recovered_tokens - new_tokens
+                if forecast > 0:
+                    sim_tokens = sim_tokens + new_tokens - recovered_tokens
+                    all_features[i_cmap] = code_feature
+
+        return sorted(all_features, key=_feature_relative_path)
 
     def include_file(self, path: Path):
         paths, invalid_paths = get_include_files([path], [])

--- a/mentat/code_feature.py
+++ b/mentat/code_feature.py
@@ -127,7 +127,7 @@ class CodeFeature:
             else:
                 interval = parse_intervals(split[1])
                 if len(interval) > 1:
-                    raise MentatError(f"CodeFeatures should only have on interval.")
+                    raise MentatError("CodeFeatures should only have on interval.")
                 self.interval = interval[0]
                 level = CodeMessageLevel.INTERVAL
         self.level = level

--- a/mentat/code_feature.py
+++ b/mentat/code_feature.py
@@ -3,9 +3,10 @@ from __future__ import annotations
 import asyncio
 import math
 import os
+from collections import OrderedDict, defaultdict
 from enum import Enum
 from pathlib import Path
-from typing import Optional
+from typing import Optional, Set
 
 from mentat.code_map import get_code_map, get_ctags
 from mentat.diff_context import annotate_file_message, parse_diff
@@ -227,3 +228,62 @@ async def count_feature_tokens(features: list[CodeFeature], model: str) -> list[
 
     tasks = [_count_tokens(f) for f in features]
     return await asyncio.gather(*tasks)
+
+
+def get_code_message_from_intervals(features: list[CodeFeature]) -> list[str]:
+    """Merge multiple features for the same file into a single code message"""
+    features_sorted = sorted(features, key=lambda f: f.interval.start)
+    posix_path = features_sorted[0].get_code_message()[0]
+    code_message = [posix_path]
+    next_line = 1
+    for feature in features_sorted:
+        starting_line = feature.interval.start
+        if starting_line < next_line:
+            raise MentatError("Features overlap")
+        elif starting_line > next_line:
+            code_message += ["..."]
+        code_message += feature.get_code_message()[1:-1]
+        next_line = feature.interval.end
+    return code_message + [""]
+
+
+def get_code_message_from_features(features: list[CodeFeature]) -> list[str]:
+    """Generate a code message from a list of features"""
+    code_message = list[str]()
+    features_by_path: dict[Path, list[CodeFeature]] = OrderedDict()
+    for feature in features:
+        if feature.path not in features_by_path:
+            features_by_path[feature.path] = list[CodeFeature]()
+        features_by_path[feature.path].append(feature)
+    for path_features in features_by_path.values():
+        if len(path_features) == 1:
+            code_message += path_features[0].get_code_message()
+        else:
+            code_message += get_code_message_from_intervals(path_features)
+    return code_message
+
+
+def code_features_difference(
+    a: list[CodeFeature], b: list[CodeFeature]
+) -> dict[Path, Set[int]]:
+    def _get_lines(features: list[CodeFeature]) -> dict[Path, Set[int]]:
+        lines: defaultdict[Path, Set[int]] = defaultdict(set)
+        for feature in features:
+            if feature.interval.end == math.inf:
+                n_lines = len(feature.path.read_text().splitlines())
+                start, end = 1, n_lines + 1
+            else:
+                start, end = feature.interval.start, feature.interval.end
+            for line in range(int(start), int(end)):
+                lines[feature.path].add(line)
+        return dict(lines)
+
+    a_lines = _get_lines(a)
+    b_lines = _get_lines(b)
+    differences: defaultdict[Path, Set[int]] = defaultdict(set)
+    for file in a_lines:
+        difference = a_lines[file] - b_lines[file]
+        if len(difference) > 0:
+            differences[file] = difference
+
+    return dict(differences)

--- a/mentat/config.py
+++ b/mentat/config.py
@@ -37,6 +37,7 @@ class Config:
 
     # Model specific settings
     model: str = attr.field(default="gpt-4-0314")
+    feature_selection_model: str = attr.field(default="gpt-4-0314")
     temperature: float = attr.field(
         default=0.5, converter=float, validator=[validators.le(1), validators.ge(0)]
     )

--- a/mentat/resources/prompts/feature_selection_prompt.txt
+++ b/mentat/resources/prompts/feature_selection_prompt.txt
@@ -2,7 +2,7 @@ You are part of an automated coding system.
 Below you will see the line 'User Query:', followed by a user query, followed by the line 'Code Files:' and then a pre-selected subset of a codebase.
 Your job is to select portions of the code which are relevant to answering that query.
 The process after you will read the lines code you select, and then return a plaintext plan of action and a list of Code Edits.
-{{training_prompt}}
+{training_prompt}
 Each item in the Code Files below will include a relative path and line numbers.
 Identify lines of code which are relevant to the query.
 Return a json-serializable list of relevant items following the same format you receive: <rel_path>:<start_line>-<end_line>,<start_line>-<end_line>.
@@ -11,5 +11,6 @@ It's equally important to exclude irrelevant code, as it has a negative impact o
 For example: if a question requires creating a new method related to a class, and the method uses an attribute of that
 class, include the location for the edit as well as where the attribute is defined. If a typing system is used, include
 the type definition as well, and the location of the expected import.
+Prefer longer intervals with 5 lines of extra spacing added around target lines.
 Make sure your response is valid json, for example:
 ["path/to/file1.py:1-10,53-60", "path/to/file2.py:10-20"]

--- a/mentat/resources/prompts/feature_selection_prompt.txt
+++ b/mentat/resources/prompts/feature_selection_prompt.txt
@@ -1,0 +1,15 @@
+You are part of an automated coding system. 
+Below you will see the line 'User Query:', followed by a user query, followed by the line 'Code Files:' and then a pre-selected subset of a codebase.
+Your job is to select portions of the code which are relevant to answering that query.
+The process after you will read the lines code you select, and then return a plaintext plan of action and a list of Code Edits.
+{{training_prompt}}
+Each item in the Code Files below will include a relative path and line numbers.
+Identify lines of code which are relevant to the query.
+Return a json-serializable list of relevant items following the same format you receive: <rel_path>:<start_line>-<end_line>,<start_line>-<end_line>.
+It's important to include lines which would be edited in order to generate the answer as well as lines which are required to understand the context.
+It's equally important to exclude irrelevant code, as it has a negative impact on the system performance and cost.
+For example: if a question requires creating a new method related to a class, and the method uses an attribute of that
+class, include the location for the edit as well as where the attribute is defined. If a typing system is used, include
+the type definition as well, and the location of the expected import.
+Make sure your response is valid json, for example:
+["path/to/file1.py:1-10,53-60", "path/to/file2.py:10-20"]

--- a/mentat/resources/prompts/feature_selection_prompt_training.txt
+++ b/mentat/resources/prompts/feature_selection_prompt_training.txt
@@ -1,0 +1,1 @@
+You are currently being used to generate benchmarking data, so you'll be shown those Code Edits as well in order to maximize your performance.

--- a/mentat/resources/prompts/feature_selection_prompt_training.txt
+++ b/mentat/resources/prompts/feature_selection_prompt_training.txt
@@ -1,1 +1,3 @@
 You are currently being used to generate benchmarking data, so you'll be shown those Code Edits as well in order to maximize your performance.
+Make sure you don't only include the files/lines in those edits, but also 5 lines of padding in either direction,
+as well as unchanged but relevant segments of code from the codebase. 

--- a/scripts/git_log_to_transcripts.py
+++ b/scripts/git_log_to_transcripts.py
@@ -7,7 +7,6 @@ import os
 import subprocess
 from pathlib import Path
 from textwrap import dedent
-from unittest.mock import AsyncMock
 
 import openai
 from git import Repo

--- a/scripts/git_log_to_transcripts.py
+++ b/scripts/git_log_to_transcripts.py
@@ -3,10 +3,8 @@
 import argparse
 import asyncio
 import json
-import math
 import os
 import subprocess
-from collections import defaultdict
 from pathlib import Path
 from textwrap import dedent
 

--- a/scripts/git_log_to_transcripts.py
+++ b/scripts/git_log_to_transcripts.py
@@ -173,9 +173,9 @@ async def translate_commits_to_transcripts(repo, count=10):
                     edited_files - selected_files,
                 )
                 print("Using edited_files instead")
-                benchmark["expected_features"] = edited_files
+                benchmark["expected_features"] = list(edited_files)
             else:
-                benchmark["expected_features"] = selected_features
+                benchmark["expected_features"] = list(selected_features)
 
             benchmarks[sha] = benchmark
         except Exception as e:

--- a/tests/auto_context_test.py
+++ b/tests/auto_context_test.py
@@ -1,0 +1,83 @@
+from pathlib import Path
+from unittest.mock import AsyncMock
+
+import pytest
+
+from mentat.auto_context import (
+    GreedyFeatureSelector,
+    LLMFeatureSelector,
+    get_feature_selector,
+)
+from mentat.code_feature import CodeFeature, CodeMessageLevel
+
+
+def test_get_feature_selector():
+    s1 = get_feature_selector(use_llm=False)
+    assert isinstance(s1, GreedyFeatureSelector)
+    s2 = get_feature_selector(use_llm=True)
+    assert isinstance(s2, LLMFeatureSelector)
+
+
+@pytest.mark.asyncio
+async def test_greedy_feature_selector(temp_testbed, mock_session_context):
+    all_features = [
+        CodeFeature(
+            temp_testbed / "multifile_calculator" / "calculator.py"
+        ),  # 188 tokens
+        CodeFeature(
+            temp_testbed / "multifile_calculator" / "operations.py"
+        ),  # 87 tokens
+    ]
+
+    # No levels provided: take it or leave it
+    selector = GreedyFeatureSelector()
+    selected = await selector.select(all_features, 100)
+    assert len(selected) == 1
+    assert selected[0].path.name == "operations.py"
+
+    selected = await selector.select(all_features, 200)
+    assert len(selected) == 1
+    assert selected[0].path.name == "calculator.py"
+
+    # If levels are provided, take the largest one that fits.
+    selected = await selector.select(
+        all_features, 100, levels=[CodeMessageLevel.FILE_NAME]
+    )
+    assert len(selected) == 2
+    assert selected[0].level.key == "file_name"
+    assert selected[1].level.key == "code"
+
+
+@pytest.mark.asyncio
+async def test_llm_feature_selector(
+    mocker, temp_testbed, mock_session_context, mock_setup_api_key
+):
+    all_features = [
+        CodeFeature(
+            temp_testbed / "multifile_calculator" / "calculator.py"
+        ),  # 188 tokens
+        CodeFeature(
+            temp_testbed / "multifile_calculator" / "operations.py"
+        ),  # 87 tokens
+    ]
+
+    mock_completion = mocker.patch(
+        "mentat.auto_context.LLMFeatureSelector.call_llm_api", new_callable=AsyncMock
+    )
+    mock_completion.return_value = '["multifile_calculator/operations.py"]'
+
+    selector = LLMFeatureSelector()
+    selected = await selector.select(all_features, 100, user_prompt="test prompt")
+
+    model, messages = mock_completion.call_args.args
+    assert messages[0]["content"].startswith("You are part of")
+    assert "User Query:\ntest prompt\n\nCode Files:" in messages[1]["content"]
+
+    # Both files send to llm
+    assert all(
+        str(f.path.relative_to(temp_testbed)) in messages[1]["content"]
+        for f in all_features
+    )
+
+    # Only one file returned
+    assert len(selected) == 1

--- a/tests/auto_context_test.py
+++ b/tests/auto_context_test.py
@@ -74,7 +74,7 @@ async def test_llm_feature_selector(
 
     # Both files send to llm
     assert all(
-        str(f.path.relative_to(temp_testbed)) in messages[1]["content"]
+        f.path.relative_to(temp_testbed).as_posix() in messages[1]["content"]
         for f in all_features
     )
 

--- a/tests/auto_context_test.py
+++ b/tests/auto_context_test.py
@@ -1,4 +1,3 @@
-from pathlib import Path
 from unittest.mock import AsyncMock
 
 import pytest

--- a/tests/benchmarks/context_benchmark.py
+++ b/tests/benchmarks/context_benchmark.py
@@ -29,7 +29,6 @@ a lot higher.
 
 import json
 import os
-import subprocess
 from collections import defaultdict
 from itertools import islice
 from pathlib import Path
@@ -42,7 +41,6 @@ from mentat.code_context import CodeContext
 from mentat.code_feature import CodeFeature, CodeMessageLevel
 from mentat.code_file_manager import CodeFileManager
 from mentat.config import Config
-from mentat.git_handler import get_non_gitignored_files
 from mentat.llm_api import CostTracker, setup_api_key
 from mentat.parsers.replacement_parser import ReplacementParser
 from mentat.session_context import SESSION_CONTEXT, SessionContext

--- a/tests/benchmarks/context_benchmark.py
+++ b/tests/benchmarks/context_benchmark.py
@@ -27,89 +27,96 @@ These tests can be used to train/score #1 or #2, but we'd expect #2 to score
 a lot higher.
 """
 
+import json
 import os
 import subprocess
+from collections import defaultdict
+from itertools import islice
 from pathlib import Path
+from typing import Any
 
 import pytest
+from git import Repo
 
 from mentat.code_context import CodeContext
 from mentat.code_feature import CodeFeature, CodeMessageLevel
+from mentat.code_file_manager import CodeFileManager
+from mentat.config import Config
 from mentat.git_handler import get_non_gitignored_files
-from mentat.llm_api import setup_api_key
-from mentat.session_context import SESSION_CONTEXT
+from mentat.llm_api import CostTracker, setup_api_key
+from mentat.parsers.replacement_parser import ReplacementParser
+from mentat.session_context import SESSION_CONTEXT, SessionContext
+from scripts.git_log_to_transcripts import MockStream
 from tests.benchmarks.utils import clone_repo
 
 pytestmark = pytest.mark.benchmark
 
-benchmarks_dir = Path(__file__).parent / "repo/for_transcripts"
+benchmarks_dir = Path(__file__).parent / "repos/for_transcripts"
 
 
-def load_tests():
+def load_tests() -> dict[str, dict[str, Any]]:
+    tests = {}
     benchmarks_path = benchmarks_dir / "benchmarks.json"
     if benchmarks_path.exists():
         with open(benchmarks_path, "r") as f:
             tests = json.load(f)
-    return []
+    return tests
 
 
-# tests = [
-#     {
-#         "name": "Mentat: replace subprocess/git with GitPython",
-#         "codebase_url": "http://github.com/AbanteAI/mentat",
-#         "codebase_name": "mentat",
-#         "commit": "a9f055e",
-#         "args": {"paths": ["mentat/__init__.py"]},
-#         "prompt": (
-#             "I want to update all the files in git_handler to use the 'Repo' class from"
-#             " GitPython instead of calling subprocess. Update each function in"
-#             " mentat/git_handler.py that calls subprocess to use Repo instead. If git"
-#             " is run with subprocess anywhere in the code, update those as well."
-#         ),
-#         "expected_features": [
-#             "mentat/git_handler.py",
-#             "mentat/diff_context.py:173-179",
-#             "tests/benchmark_test.py:118-139",
-#             "tests/commands_test.py:26-34",
-#             "tests/conftest.py:259-266",
-#             "tests/diff_context_test.py",
-#             "tests/git_handler_test.py:23-30",
-#             "tests/clients/terminal_client_test.py:62-93",
-#         ],
-#         "expected_edits": [
-#             # for other benchmarks
-#         ],
-#     },
-#     {
-#         "name": "simoc-abm: Change 'Lamp' to 'Electric Light'",
-#         "codebase_url": "http://github.com/overthesun/simoc-abm",
-#         "codebase_name": "simoc-abm",
-#         "commit": "d77f44f",
-#         "args": {"ignore_paths": ["src/simoc_abm/data_files", "test/*"]},
-#         "prompt": (
-#             "Rename 'lamp' to 'electric light' throughout the code. Update "
-#             "instances of 'lamp' to 'electric_light', and 'Lamp' to 'Electric "
-#             "Light', and if there's a class Lamp, should be class ElectricLight."
-#         ),
-#         "expected_features": [
-#             "docs/api.rst:21-22",
-#             "src/simoc_abm/agent_model.py:129-230",
-#             "src/simoc_abm/agents/__init__.py",
-#             "src/simoc_abm/agents/lamp.py",
-#             "src/simoc_abm/agents/plant.py:135-197",
-#         ],
-#         "expected_edits": [],
-#     },
-# ]
+def features_to_line_sets(
+    git_root: Path, features: list[CodeFeature]
+) -> defaultdict[set]:
+    lines = defaultdict(set)
+    for feature in features:
+        # Non-explicit features (e.g. CodeMaps) are considered false positives.
+        # Using negative numbers here as that affect.
+        if feature.level not in (CodeMessageLevel.CODE, CodeMessageLevel.INTERVAL):
+            n_lines = len(feature.get_code_message())
+            lines[feature.path].update(range(-1, -n_lines - 1, -1))
+            continue
+
+        # Otherwise match specific lines
+        path = feature.path.relative_to(git_root)
+        if feature.level == CodeMessageLevel.INTERVAL:
+            intervals = [(f.start, f.end) for f in feature.intervals]
+        else:
+            n_lines = len(feature.get_code_message())
+            intervals = [(1, n_lines + 1)]
+        for start, end in intervals:
+            lines[path].update(range(start, end + 1))
+    return lines
 
 
-def matches(test, name):
-    prefix_length = min(len(test["commit"]), len(name))
-    if test["commit"][:prefix_length] == name[:prefix_length]:
-        return True
-    if name in test["name"]:
-        return True
-    return False
+def evaluate(
+    git_root: Path, actual: list[CodeFeature], expected: list[CodeFeature]
+) -> dict[str, float]:
+    actual_lines = features_to_line_sets(git_root, actual)
+    expected_lines = features_to_line_sets(git_root, expected)
+
+    _TP, _FP, _FN = 0, 0, 0
+    for file in actual_lines | expected_lines:
+        actual_set = actual_lines[file]
+        expected_set = expected_lines[file]
+        _TP += len(actual_set & expected_set)
+        _FP += len(actual_set - expected_set)
+        _FN += len(expected_set - actual_set)
+
+    print(f"True Positive:\t{_TP:.3f}")
+    print(f"False Positive:\t{_FP:.3f}")
+    print(f"False Negative:\t{_FN:.3f}")
+
+    precision, recall = None, None
+    if (_TP + _FP) > 0:
+        precision = _TP / (_TP + _FP)
+        print(
+            f"Precision:\t{precision:.3f}\t| How many selected features are relevant?"
+        )
+    if (_TP + _FN) > 0:
+        recall = _TP / (_TP + _FN)
+        print(f"Recall:\t\t{recall:.3f}\t| How many relevant features are selected?")
+    if precision and recall:
+        f1 = 2 * precision * recall / (precision + recall)
+        print(f"F1:\t\t{f1:.3f}\t| Weighted average of precision and recall")
 
 
 @pytest.mark.asyncio
@@ -120,82 +127,48 @@ async def test_code_context_performance(
     tests = load_tests()
 
     if len(benchmarks) > 0:
-        tests_to_run = []
-        for test in tests:
-            for benchmark in benchmarks:
-                if matches(test, benchmark):
-                    tests_to_run.append(test)
-                    break
+        tests_to_run = {k: v for k, v in tests.items() if k in benchmarks}
     else:
-        tests_to_run = tests[:max_benchmarks]
+        tests_to_run = dict(islice(tests.items(), max_benchmarks))
 
-    for test in tests_to_run:
+    for test in tests_to_run.values():
         print(f"\n\n{test['name']}\n{test['prompt']}")
 
-        code_dir = clone_repo(test["codebase_url"], test["codebase_name"])
-        os.chdir(code_dir)
-        if test["commit"]:
-            subprocess.run(
-                ["git", "checkout", test["commit"]],
-                stdout=subprocess.DEVNULL,
-                stderr=subprocess.DEVNULL,
-            )
-        mock_session_context.git_root = code_dir
+        # Setup the cwd the same way as in generate
+        codebase = clone_repo(test["codebase_url"], "for_transcripts")
+        os.chdir(codebase)
 
+        # Initialize a full SESSION_CONTEXT
+        stream = MockStream()
+        git_root = Path.cwd()
+        config = Config(use_embeddings=True, auto_tokens=7000)
+        code_context = CodeContext(stream, os.getcwd())
         paths = test["args"].get("paths", [])
         exclude_paths = test["args"].get("exclude_paths", [])
         ignore_paths = test["args"].get("ignore_paths", [])
-        rest = {
-            k: v
-            for k, v in test["args"].items()
-            if k not in ["paths", "exclude_paths", "ignore_paths"]
-        }
-        session_context = SESSION_CONTEXT.get()
-        config = session_context.config
-        config.use_embeddings = True
-        config.auto_tokens = 7000
-        for k in rest:
-            if hasattr(config, k):
-                setattr(config, k, rest[k])
-        code_context = CodeContext(
-            stream=mock_session_context.stream,
-            git_root=code_dir,
-        )
         code_context.set_paths(paths, exclude_paths, ignore_paths)
+        session_context = SessionContext(
+            stream,
+            CostTracker(),
+            git_root,
+            config,
+            ReplacementParser(),
+            code_context,
+            CodeFileManager(),
+            None,
+        )
+        SESSION_CONTEXT.set(session_context)
+        repo = Repo(".")
+        repo.git.checkout(test["commit"])
+
+        # Get results with and without llm
+        expected_features = [
+            CodeFeature(git_root / f) for f in test["expected_features"]
+        ]
+
         _ = await code_context.get_code_message(test["prompt"], "gpt-4", 7000)
+        evaluate(git_root, code_context.features, expected_features)
 
-        # Calculate y_pred and y_true
-        actual = {
-            f.path for f in code_context.features if f.level == CodeMessageLevel.CODE
-        }
-        expected_features = {
-            CodeFeature(f).path for f in test["expected_features"]
-        }  # Ignore line numbers for now
-        all_files = [Path(f) for f in get_non_gitignored_files(code_dir)]
-        y_pred = [f in actual for f in all_files]
-        y_true = [f in expected_features for f in all_files]
-
-        _TP = sum([1 for p, t in zip(y_pred, y_true) if p and t])
-        _TN = sum([1 for p, t in zip(y_pred, y_true) if not p and not t])
-        _FP = sum([1 for p, t in zip(y_pred, y_true) if p and not t])
-        _FN = sum([1 for p, t in zip(y_pred, y_true) if not p and t])
-        print(f"True Positive:\t{_TP:.3f}")
-        print(f"True Negative:\t{_TN:.3f}")
-        print(f"False Positive:\t{_FP:.3f}")
-        print(f"False Negative:\t{_FN:.3f}")
-
-        precision, recall = None, None
-        if (_TP + _FP) > 0:
-            precision = _TP / (_TP + _FP)
-            print(
-                f"Precision:\t{precision:.3f}\t| How many selected features are"
-                " relevant?"
-            )
-        if (_TP + _FN) > 0:
-            recall = _TP / (_TP + _FN)
-            print(
-                f"Recall:\t\t{recall:.3f}\t| How many relevant features are selected?"
-            )
-        if precision and recall:
-            f1 = 2 * precision * recall / (precision + recall)
-            print(f"F1:\t\t{f1:.3f}\t| Weighted average of precision and recall")
+        code_context.use_llm = True
+        _ = await code_context.get_code_message(test["prompt"], "gpt-4", 7000)
+        evaluate(git_root, code_context.features, expected_features)

--- a/tests/benchmarks/context_benchmark.py
+++ b/tests/benchmarks/context_benchmark.py
@@ -42,54 +42,65 @@ from tests.benchmarks.utils import clone_repo
 
 pytestmark = pytest.mark.benchmark
 
-tests = [
-    {
-        "name": "Mentat: replace subprocess/git with GitPython",
-        "codebase_url": "http://github.com/AbanteAI/mentat",
-        "codebase_name": "mentat",
-        "commit": "a9f055e",
-        "args": {"paths": ["mentat/__init__.py"]},
-        "prompt": (
-            "I want to update all the files in git_handler to use the 'Repo' class from"
-            " GitPython instead of calling subprocess. Update each function in"
-            " mentat/git_handler.py that calls subprocess to use Repo instead. If git"
-            " is run with subprocess anywhere in the code, update those as well."
-        ),
-        "expected_features": [
-            "mentat/git_handler.py",
-            "mentat/diff_context.py:173-179",
-            "tests/benchmark_test.py:118-139",
-            "tests/commands_test.py:26-34",
-            "tests/conftest.py:259-266",
-            "tests/diff_context_test.py",
-            "tests/git_handler_test.py:23-30",
-            "tests/clients/terminal_client_test.py:62-93",
-        ],
-        "expected_edits": [
-            # for other benchmarks
-        ],
-    },
-    {
-        "name": "simoc-abm: Change 'Lamp' to 'Electric Light'",
-        "codebase_url": "http://github.com/overthesun/simoc-abm",
-        "codebase_name": "simoc-abm",
-        "commit": "d77f44f",
-        "args": {"ignore_paths": ["src/simoc_abm/data_files", "test/*"]},
-        "prompt": (
-            "Rename 'lamp' to 'electric light' throughout the code. Update "
-            "instances of 'lamp' to 'electric_light', and 'Lamp' to 'Electric "
-            "Light', and if there's a class Lamp, should be class ElectricLight."
-        ),
-        "expected_features": [
-            "docs/api.rst:21-22",
-            "src/simoc_abm/agent_model.py:129-230",
-            "src/simoc_abm/agents/__init__.py",
-            "src/simoc_abm/agents/lamp.py",
-            "src/simoc_abm/agents/plant.py:135-197",
-        ],
-        "expected_edits": [],
-    },
-]
+benchmarks_dir = Path(__file__).parent / "repo/for_transcripts"
+
+
+def load_tests():
+    benchmarks_path = benchmarks_dir / "benchmarks.json"
+    if benchmarks_path.exists():
+        with open(benchmarks_path, "r") as f:
+            tests = json.load(f)
+    return []
+
+
+# tests = [
+#     {
+#         "name": "Mentat: replace subprocess/git with GitPython",
+#         "codebase_url": "http://github.com/AbanteAI/mentat",
+#         "codebase_name": "mentat",
+#         "commit": "a9f055e",
+#         "args": {"paths": ["mentat/__init__.py"]},
+#         "prompt": (
+#             "I want to update all the files in git_handler to use the 'Repo' class from"
+#             " GitPython instead of calling subprocess. Update each function in"
+#             " mentat/git_handler.py that calls subprocess to use Repo instead. If git"
+#             " is run with subprocess anywhere in the code, update those as well."
+#         ),
+#         "expected_features": [
+#             "mentat/git_handler.py",
+#             "mentat/diff_context.py:173-179",
+#             "tests/benchmark_test.py:118-139",
+#             "tests/commands_test.py:26-34",
+#             "tests/conftest.py:259-266",
+#             "tests/diff_context_test.py",
+#             "tests/git_handler_test.py:23-30",
+#             "tests/clients/terminal_client_test.py:62-93",
+#         ],
+#         "expected_edits": [
+#             # for other benchmarks
+#         ],
+#     },
+#     {
+#         "name": "simoc-abm: Change 'Lamp' to 'Electric Light'",
+#         "codebase_url": "http://github.com/overthesun/simoc-abm",
+#         "codebase_name": "simoc-abm",
+#         "commit": "d77f44f",
+#         "args": {"ignore_paths": ["src/simoc_abm/data_files", "test/*"]},
+#         "prompt": (
+#             "Rename 'lamp' to 'electric light' throughout the code. Update "
+#             "instances of 'lamp' to 'electric_light', and 'Lamp' to 'Electric "
+#             "Light', and if there's a class Lamp, should be class ElectricLight."
+#         ),
+#         "expected_features": [
+#             "docs/api.rst:21-22",
+#             "src/simoc_abm/agent_model.py:129-230",
+#             "src/simoc_abm/agents/__init__.py",
+#             "src/simoc_abm/agents/lamp.py",
+#             "src/simoc_abm/agents/plant.py:135-197",
+#         ],
+#         "expected_edits": [],
+#     },
+# ]
 
 
 def matches(test, name):
@@ -106,6 +117,7 @@ async def test_code_context_performance(
     mock_session_context, benchmarks, max_benchmarks
 ):
     setup_api_key()
+    tests = load_tests()
 
     if len(benchmarks) > 0:
         tests_to_run = []

--- a/tests/benchmarks/context_benchmark.py
+++ b/tests/benchmarks/context_benchmark.py
@@ -76,12 +76,11 @@ def features_to_line_sets(
         # Otherwise match specific lines
         path = feature.path.relative_to(git_root)
         if feature.level == CodeMessageLevel.INTERVAL:
-            intervals = [(f.start, f.end) for f in feature.intervals]
+            interval = feature.interval
         else:
             n_lines = len(feature.get_code_message())
-            intervals = [(1, n_lines + 1)]
-        for start, end in intervals:
-            lines[path].update(range(start, end + 1))
+            interval = (1, n_lines + 1)
+        lines[path].update(range(interval.start, interval.end + 1))
     return lines
 
 

--- a/tests/benchmarks/utils.py
+++ b/tests/benchmarks/utils.py
@@ -6,7 +6,7 @@ from git import Repo
 CLONE_TO_DIR = Path(__file__).parent / "repos"
 
 
-def clone_repo(url: str, local_dir_name: str, refresh: bool = False) -> None:
+def clone_repo(url: str, local_dir_name: str, refresh: bool = False) -> Path:
     local_dir = CLONE_TO_DIR / local_dir_name
     if os.path.exists(local_dir):
         if refresh:

--- a/tests/code_context_test.py
+++ b/tests/code_context_test.py
@@ -305,7 +305,7 @@ async def test_auto_tokens(mocker, temp_testbed, mock_session_context):
     async def _count_auto_tokens_where(limit: int) -> int:
         mocker.patch.object(Config, "auto_tokens", new=limit)
         code_message = await code_context.get_code_message(
-            prompt="", model="gpt-4", max_tokens=1e6
+            prompt="", model="gpt-4", max_tokens=limit or 1e6
         )
         return count_tokens(code_message, "gpt-4")
 

--- a/tests/code_context_test.py
+++ b/tests/code_context_test.py
@@ -305,11 +305,12 @@ async def test_auto_tokens(mocker, temp_testbed, mock_session_context):
     async def _count_auto_tokens_where(limit: int) -> int:
         mocker.patch.object(Config, "auto_tokens", new=limit)
         code_message = await code_context.get_code_message(
-            prompt="", model="gpt-4", max_tokens=limit or 1e6
+            prompt="", model="gpt-4", max_tokens=limit
         )
         return count_tokens(code_message, "gpt-4")
 
-    assert await _count_auto_tokens_where(None) == 65  # Cmap w/ signatures
+    assert await _count_auto_tokens_where(1e6) == 85  # Code
+    assert await _count_auto_tokens_where(84) == 65  # Cmap w/ signatures
     assert await _count_auto_tokens_where(60) == 57  # Cmap
     assert await _count_auto_tokens_where(52) == 47  # fnames
     # Always return include_files, regardless of max

--- a/tests/code_context_test.py
+++ b/tests/code_context_test.py
@@ -275,7 +275,7 @@ async def test_get_code_message_include(mocker, temp_testbed, mock_session_conte
 
 @pytest.mark.asyncio
 @pytest.mark.clear_testbed
-async def test_max_tokens(mocker, temp_testbed, mock_session_context):
+async def test_auto_tokens(mocker, temp_testbed, mock_session_context):
     with open("file_1.py", "w") as f:
         f.write(dedent("""\
             def func_1(x, y):
@@ -302,19 +302,18 @@ async def test_max_tokens(mocker, temp_testbed, mock_session_context):
     )
     code_context.set_paths(["file_1.py"], [])
 
-    mocker.patch.object(Config, "auto_tokens", new=1e6)
-
-    async def _count_tokens_with_max(limit: int) -> int:
+    async def _count_auto_tokens_where(limit: int) -> int:
+        mocker.patch.object(Config, "auto_tokens", new=limit)
         code_message = await code_context.get_code_message(
-            prompt="", model="gpt-4", max_tokens=limit
+            prompt="", model="gpt-4", max_tokens=1e6
         )
         return count_tokens(code_message, "gpt-4")
 
-    assert await _count_tokens_with_max(1e6) == 65  # Cmap w/ signatures
-    assert await _count_tokens_with_max(60) == 57  # Cmap
-    assert await _count_tokens_with_max(52) == 47  # fnames
+    assert await _count_auto_tokens_where(None) == 65  # Cmap w/ signatures
+    assert await _count_auto_tokens_where(60) == 57  # Cmap
+    assert await _count_auto_tokens_where(52) == 47  # fnames
     # Always return include_files, regardless of max
-    assert await _count_tokens_with_max(0) == 42  # Include_files only
+    assert await _count_auto_tokens_where(0) == 42  # Include_files only
 
 
 @pytest.mark.clear_testbed

--- a/tests/code_feature_test.py
+++ b/tests/code_feature_test.py
@@ -18,18 +18,17 @@ def test_split_file_into_intervals(temp_testbed, mock_session_context):
 
     assert len(interval_features) == 2
 
-    interval_1 = interval_features[0].intervals[0]
-    interval_2 = interval_features[1].intervals[0]
-    assert (interval_1.start, interval_1.end) == (0, 3)
+    interval_1 = interval_features[0].interval
+    interval_2 = interval_features[1].interval
+    assert (interval_1.start, interval_1.end) == (1, 4)
     assert (interval_2.start, interval_2.end) == (4, 6)
 
 
 def test_ref_method(temp_testbed):
     test_file = Path(temp_testbed) / "test_file.py"
     test_file.write_text("\n".join([""] * 10))
-    expected = "test_file.py:2-4,6-8"
+    expected = "test_file.py:2-4"
     code_feature = CodeFeature(expected, CodeMessageLevel.INTERVAL)
-    assert (code_feature.intervals[0].start, code_feature.intervals[0].end) == (2, 4)
-    assert (code_feature.intervals[1].start, code_feature.intervals[1].end) == (6, 8)
+    assert (code_feature.interval.start, code_feature.interval.end) == (2, 4)
     ref_result = code_feature.ref()
     assert ref_result == expected

--- a/tests/code_file_manager_test.py
+++ b/tests/code_file_manager_test.py
@@ -58,6 +58,7 @@ async def test_partial_files(mocker, mock_session_context):
 
             dir/file.txt
             1:I am a file
+            ...
             3:third
             4:fourth
             5:fifth


### PR DESCRIPTION
Add the ability to use llm for context selection in benchmarks. In future PRs we'll add a command/arg to use this in the actual mentat - this lays the groundwork for that.

- Move auto-context logic from `CodeContext._get_auto_features` to `mentat.auto_context.py`
- Define two algos: _greedy (reproduce current results) and _llm
- Use _llm algo in `get_git_log_transcripts` to build benchmark['expected_features'].

What this branch can do is:
1. Generate benchmarks using @jakethekoenig's script: `./scripts/git_log_to_transcripts.py --repo <gh-link>`
2. Run context_benchmarks against the created benchmarks: `pytest -s tests/benchmarks/context_benchmark.py --benchmarks`. This will print your precision/recall first with the greedy method, then llm. 