### PR TITLE
Fix: --diff/--pr-diff

### DIFF
--- a/mentat/diff_context.py
+++ b/mentat/diff_context.py
@@ -131,7 +131,7 @@ class DiffContext:
                 self.name = "HEAD (last commit)"
                 return
 
-        meta = get_treeish_metadata(target)
+        meta = get_treeish_metadata(target, git_root=git_root)
         name += f'{meta["hexsha"][:8]}: {meta["summary"]}'
 
         self.target = target

--- a/mentat/git_handler.py
+++ b/mentat/git_handler.py
@@ -124,9 +124,10 @@ def get_diff_for_file(target: str, path: Path) -> str:
         raise UserError()
 
 
-def get_treeish_metadata(target: str) -> dict[str, str]:
-    session_context = SESSION_CONTEXT.get()
-    git_root = session_context.git_root
+def get_treeish_metadata(target: str, git_root: Path | None = None) -> dict[str, str]:
+    if git_root is None:
+        session_context = SESSION_CONTEXT.get()
+        git_root = session_context.git_root
 
     try:
         commit_info = subprocess.check_output(


### PR DESCRIPTION
These flags weren't working because the SESSION_CONTEXT wasn't initialized when get_treeish_metadata was called.