### PR TITLE
Git Parser Fix

### DIFF
--- a/mentat/parsers/git_parser.py
+++ b/mentat/parsers/git_parser.py
@@ -62,8 +62,17 @@ class GitParser:
             if not is_deletion:
                 for change in diff_split[1:]:
                     line_info = change.split("@@")[0]
-                    start_line = int(line_info.split()[0].split(",")[0][1:]) - 1
-                    end_line = start_line + int(line_info.split()[0].split(",")[1])
+                    # Git diff line represents line number information:
+                    # @@ -a,b +c,d @@
+                    # a is the original starting line number and b is the original number of lines.
+                    # c and d are the new values.
+                    # Both b and d are omitted when 1.
+                    a_b = line_info.split()[0].split(",")
+                    start_line = int(a_b[0][1:]) - 1
+                    if len(a_b) == 1:
+                        end_line = start_line + 1
+                    else:
+                        end_line = start_line + int(a_b[1])
                     line_changes = change.split("@@")[1]
                     code_lines = line_changes.split("\n")
                     # This check is necessary because new code sometimes starts on the same line

--- a/testbed/format_examples/block.txt
+++ b/testbed/format_examples/block.txt
@@ -38,3 +38,13 @@ Fifth commit
     "end-line": 8
 }
 @@end
+@@start
+{
+    "file": "f",
+    "action": "replace",
+    "start-line": 1,
+    "end-line": 1
+}
+@@code
+bar
+@@end

--- a/testbed/format_examples/git_diff.txt
+++ b/testbed/format_examples/git_diff.txt
@@ -55,3 +55,10 @@ index ec588a0..720a0a7 100644
  9
  0
  
+diff --git a/f b/f
+index ec588a0..720a0a7 100644
+--- a/f
++++ b/f
+@@ -1 +1 @@
+-foo
++bar

--- a/testbed/format_examples/replacement.txt
+++ b/testbed/format_examples/replacement.txt
@@ -14,3 +14,6 @@ Fifth commit
 @ c e
 @ c starting_line=8 ending_line=8
 @
+@ f starting_line=1 ending_line=1
+bar
+@


### PR DESCRIPTION
When a git diff shows exactly one line changed the number which says how many lines were changed is omitted. This is rarer than it sounds because git usually gives context around a change. But it happens for one line files like .nvmrcs.