### PR TITLE
Git transcript processing tweaks

### DIFF
--- a/scripts/git_log_to_transcripts.py
+++ b/scripts/git_log_to_transcripts.py
@@ -21,23 +21,34 @@ from mentat.parsers.replacement_parser import ReplacementParser
 from mentat.session_context import SESSION_CONTEXT, SessionContext
 from tests.benchmarks.utils import clone_repo
 
+
 system_prompt = dedent("""\
         You are part of an automated system for making synthetic data. You will be given the \
-        output of `git show` for a commit. Your job is to write down what could have been a \
-        user request that would lead to this commit. Focus more on the feature added or bug \
-        fixed or the why of the commit than on the exact code changes. End that message with \
-        END. Then write a step by step plan which if followed would lead to this commit. \
-        Please respond with only those two things separated by END. Do not prepend either \
-        one with additional labels such as "User Request:" or "Plan:". Don't surround either \
-        with quotes or other delimiters. Don't mention mechanical details like what tools you \
-        might use or the need to open files in your step by step guide. Focus on the changes \
-        themselves. Number your steps 1,2,3... Put each step on its own line.""")
+        output of `git show` for a commit. Please respond only in json. The json should have \
+        the following entries:
+        - request (type string): a user request that would lead to this commit. Focus more on \
+        the feature added or bug fixed or the why of the commit than on the exact code changes.
+        - plan (type string): a step by step plan which if followed would lead to this commit. \
+        Your plan should be numbered 1,2,3... with each step separated by a newline. Don't \
+        mention mechanical details like what tools you might use or the need to open files. \
+        Focus on the sequence of changes necessary.
+        - documentation (type boolean): True if this change is mostly or entirely changes to \
+        the documentation.
+        - configuration (type boolean): True if this change only affects configuration. For \
+        example deploy scripts, dependency versioning, or linting/compiler options.
+        - bug (type boolean): True if this change is a bug fix.
+        - feature (type boolean): True if this change is a new feature.
+        - complexity (type int): On a scale of 1 to 10 rate how interesting you think this \
+        change is. Use your judgement.
+        """)
+
+commit_information = "commit_information.json"
 
 
-def ask_gpt_for_prompt_and_plan(hexsha, diff):
+def gpt_commit_summary(hexsha, diff):
     # TODO: cache the cache
-    if os.path.exists("gpt-output-cache.json"):
-        with open("gpt-output-cache.json", "r") as f:
+    if os.path.exists(commit_information):
+        with open(commit_information, "r") as f:
             cache = json.load(f)
     else:
         cache = {}
@@ -55,16 +66,22 @@ def ask_gpt_for_prompt_and_plan(hexsha, diff):
     )
 
     message = response["choices"][0]["message"]["content"]
-    ans = {
-        "request": message.split("END")[0].strip(),
-        "plan": message.split("END")[1].strip(),
-    }
+
+    ans = json.loads(message)
 
     cache[hexsha] = ans
-    with open("gpt-output-cache.json", "w") as f:
+    with open(commit_information, "w") as f:
         json.dump(cache, f)
 
     return ans
+
+
+def update_cache(hexsha, value):
+    with open(commit_information, "r") as f:
+        cache = json.load(f)
+        cache[hexsha] = value
+    with open(commit_information, "w") as f:
+        json.dump(cache, f)
 
 
 def bound_files(file_edits, padding=5):
@@ -103,24 +120,22 @@ async def translate_commits_to_transcripts(repo, count=10):
             print("SHA:", sha)
             # Necessary for CodeContext to work
             repo.git.checkout(commit.parents[0].hexsha)
-            shown = subprocess.check_output(["git", "show", sha]).decode("utf-8")
+            shown = subprocess.check_output(
+                ["git", "show", sha, "-m", "--first-parent"]
+            ).decode("utf-8")
             if count_tokens(shown, "gpt-4") > 6000:
                 print("Skipping because too long")
                 continue
 
             parsedLLMResponse = GitParser().parse_string(shown)
-            # There are a lot of empty commits because they are created when another
-            # author merges a PR without squashing.
-            if len(parsedLLMResponse.file_edits) == 0:
-                continue
 
             code_context = CodeContext(AsyncMock(), os.getcwd())
             code_context.set_paths(bound_files(parsedLLMResponse.file_edits), [])
 
             code_message = await code_context.get_code_message("", "gpt-4-0314", 0)
-            prompt_and_plan = ask_gpt_for_prompt_and_plan(sha, shown)
-            prompt = prompt_and_plan["request"]
-            plan = prompt_and_plan["plan"]
+            commit_summary = gpt_commit_summary(sha, shown)
+            prompt = commit_summary["request"]
+            plan = commit_summary["plan"]
             parsedLLMResponse.conversation = plan
 
             llmResponse = ReplacementParser().file_edits_to_llm_message(
@@ -133,6 +148,10 @@ async def translate_commits_to_transcripts(repo, count=10):
                     {"role": "assistant", "content": llmResponse},
                 ]
             }
+            commit_summary["mocked_conversation"] = conversation
+
+            update_cache(sha, commit_summary)
+
             transcript = json.dumps(conversation)
             transcripts[sha] = transcript
             benchmark = {
@@ -148,6 +167,8 @@ async def translate_commits_to_transcripts(repo, count=10):
             }
             benchmarks[sha] = benchmark
         except Exception as e:
+            # You may see "this is a directory" errors. This is caused by git commits
+            # to sub projects which we don't want to process anyway.
             print(e)
             continue
     return transcripts, benchmarks
@@ -164,7 +185,7 @@ if __name__ == "__main__":
     parser.add_argument(
         "--commit",
         type=str,
-        default="HEAD",
+        default="main",
         help="The commit to convert to a transcript",
     )
     parser.add_argument(
@@ -174,12 +195,9 @@ if __name__ == "__main__":
         help="The number of commits to convert to transcripts",
     )
     args = parser.parse_args()
-    clone_repo(args.repo, "for_transcripts")
-    os.chdir("tests/benchmarks/repos/for_transcripts")
-    old_transcripts = {}
-    if os.path.exists("transcripts.jsonl"):
-        with open("transcripts.jsonl", "r") as f:
-            old_transcripts = json.loads(f.read())
+    repo_name = args.repo.split("/")[-1]
+    clone_repo(args.repo, repo_name, depth=args.count)
+    os.chdir(f"tests/benchmarks/repos/{repo_name}")
     old_benchmarks = {}
     if os.path.exists("benchmarks.json"):
         with open("benchmarks.json", "r") as f:
@@ -201,47 +219,15 @@ if __name__ == "__main__":
     SESSION_CONTEXT.set(session_context)
     repo = Repo(".")
     repo.git.checkout(args.commit)
-    transcripts, benchmarks = asyncio.run(
+    _, benchmarks = asyncio.run(
         translate_commits_to_transcripts(repo, count=args.count)
     )
-    # Everything is deterministic except for the gpt call which is cached. So transcripts
-    # and benchmarks won't change run to run unless the method is changes or the cache is
-    # removed.
-    old_transcripts.update(transcripts)
     old_benchmarks.update(benchmarks)
-    transcripts = old_transcripts
     benchmarks = old_benchmarks
     for sha, benchmark in benchmarks.items():
         benchmark["codebase_url"] = args.repo
         benchmark["codebase_name"] = args.repo.split("/")[-1]
 
-    gpt_3_examples = []
-    gpt_4_examples = []
-    gpt_3_16k_examples = []
-    gpt_4_32k_examples = []
-    for _, transcript in transcripts.items():
-        length3 = count_tokens(transcript, "gpt-3.5-turbo-0613")
-        length4 = count_tokens(transcript, "gpt-4-0613")
-        padding = 100  # Our count_tokens method isn't exactly right because chat annotations take tokens.
-        if length3 < 4097 - padding:
-            gpt_3_examples.append(transcript)
-        if length4 < 8192 - padding:
-            gpt_4_examples.append(transcript)
-        if length3 < 16385 - padding:
-            gpt_3_16k_examples.append(transcript)
-        if length4 < 32768 - padding:
-            gpt_4_32k_examples.append(transcript)
-
-    with open("transcripts.jsonl", "w") as f:
-        json.dump(transcripts, f)
-    with open("transcripts_gpt3.jsonl", "w") as f:
-        f.write("\n".join(gpt_3_examples))
-    with open("transcripts_gpt4.jsonl", "w") as f:
-        f.write("\n".join(gpt_4_examples))
-    with open("transcripts_gpt3_16k.jsonl", "w") as f:
-        f.write("\n".join(gpt_3_16k_examples))
-    with open("transcripts_gpt4_32k.jsonl", "w") as f:
-        f.write("\n".join(gpt_4_32k_examples))
     with open("benchmarks.json", "w") as f:
         json.dump(benchmarks, f)
     repo.git.checkout(args.commit)

--- a/scripts/git_log_to_transcripts.py
+++ b/scripts/git_log_to_transcripts.py
@@ -21,7 +21,6 @@ from mentat.parsers.replacement_parser import ReplacementParser
 from mentat.session_context import SESSION_CONTEXT, SessionContext
 from tests.benchmarks.utils import clone_repo
 
-
 system_prompt = dedent("""\
         You are part of an automated system for making synthetic data. You will be given the \
         output of `git show` for a commit. Please respond only in json. The json should have \

--- a/scripts/select_git_transcripts.py
+++ b/scripts/select_git_transcripts.py
@@ -1,0 +1,96 @@
+#!/usr/bin/env python
+import argparse
+import json
+import os
+from pathlib import Path
+
+from mentat.llm_api import count_tokens, model_context_size
+
+
+def select_transcripts(
+    file: str,
+    model: str,
+    count: int,
+    skip_docs: bool,
+    skip_config: bool,
+    sort_by_complexity: bool,
+):
+    with open(file, "r") as f:
+        commit_information = json.load(f)
+
+    if sort_by_complexity:
+        commit_information = sorted(
+            commit_information,
+            key=lambda info: info["complexity"],
+            reverse=True,
+        )
+
+    transcripts = []
+    for sha, info in commit_information.items():
+        if len(transcripts) >= count:
+            break
+        if skip_docs and info["documentation"]:
+            continue
+        if skip_config and info["configuration"]:
+            continue
+        if count_tokens(
+            json.dumps(info["mocked_conversation"]), model
+        ) > model_context_size(model):
+            continue
+        transcripts.append(info["mocked_conversation"])
+
+    return transcripts
+
+
+if __name__ == "__main__":
+    # Run after git_log_to_transcripts.py
+    parser = argparse.ArgumentParser(
+        description="Make a jsonl for training for a direcotry with commit information"
+    )
+    parser.add_argument(
+        "--file",
+        type=str,
+        default="tests/benchmarks/repos/mentat/commit_information.json",
+        help="The commit information file to convert to transcripts",
+    )
+    parser.add_argument(
+        "--model",
+        type=str,
+        default="gpt-3.5-turbo-0613",
+        help="The model to compute token counts with respect to",
+    )
+    parser.add_argument(
+        "--skip-docs",
+        action="store_true",
+        help="Skip transcripts that are only documentation",
+    )
+    parser.add_argument(
+        "--skip-config",
+        action="store_true",
+        help="Skip transcripts that are only configuration",
+    )
+    parser.add_argument(
+        "--sort-by-complexity",
+        action="store_true",
+        help="Return the transcripts GPT judged to be most complicated",
+    )
+    parser.add_argument(
+        "--count",
+        type=int,
+        default=10,
+        help="The number of commits to convert to transcripts",
+    )
+    args = parser.parse_args()
+    transcripts = select_transcripts(
+        args.file,
+        args.model,
+        args.count,
+        args.skip_docs,
+        args.skip_config,
+        args.sort_by_complexity,
+    )
+    directory = Path(os.path.dirname(args.file))
+
+    with open(directory / "transcripts.jsonl", "w") as f:
+        for transcript in transcripts:
+            f.write(json.dumps(transcript) + "\n")

--- a/tests/benchmarks/utils.py
+++ b/tests/benchmarks/utils.py
@@ -6,7 +6,9 @@ from git import Repo
 CLONE_TO_DIR = Path(__file__).parent / "repos"
 
 
-def clone_repo(url: str, local_dir_name: str, refresh: bool = False) -> None:
+def clone_repo(
+    url: str, local_dir_name: str, refresh: bool = False, depth: int = 0
+) -> None:
     local_dir = CLONE_TO_DIR / local_dir_name
     if os.path.exists(local_dir):
         if refresh:
@@ -15,5 +17,8 @@ def clone_repo(url: str, local_dir_name: str, refresh: bool = False) -> None:
             repo.git.clean("-fd")
             repo.remotes.origin.pull()
     else:
-        repo = Repo.clone_from(url, local_dir)
+        if depth > 0:
+            repo = Repo.clone_from(url, local_dir, depth=depth)
+        else:
+            repo = Repo.clone_from(url, local_dir)
     return local_dir


### PR DESCRIPTION
* We ask GPT to respond in json and give a little more information about the commit.
  * The mocked transcript is stored in the same cache.
* A new script is made to make the jsonls which selects transcripts with specified properties from the commit_information.json
* `git show --first-parent` is used so we can get a git diff for pull requests (thanks gpt)
* The repo name is inferred from the url instead of being constant.
* We checkout main instead of head.