### PR TITLE
Don't skip Github Action PR checks

### DIFF
--- a/.github/workflows/lint_and_test.yml
+++ b/.github/workflows/lint_and_test.yml
@@ -7,7 +7,6 @@ on: [push, pull_request]
 
 jobs:
   ruff-black-isort:
-    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name != github.event.pull_request.base.repo.full_name
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
@@ -22,7 +21,6 @@ jobs:
         run: isort --profile black --check .
 
   build:
-    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name != github.event.pull_request.base.repo.full_name
     runs-on: ${{ matrix.os }}
 
     strategy:
@@ -58,7 +56,6 @@ jobs:
           pytest
 
   license-check:
-    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name != github.event.pull_request.base.repo.full_name
     runs-on: ubuntu-latest
 
     steps:


### PR DESCRIPTION
In https://github.com/AbanteAI/mentat/pull/222 I enabled github actions checks to run on pushes to all branches, but then to reduce "duplicate" checks on PRs I disabled PR checks unless they came from another fork.

But these aren't actually duplicate checks - the "push" checks run on the commit, the "pull request" checks run on the merged code! So we definitely want the "pull request" to run!

The downside is just that we see twice as many checks at the bottom of each PR