### PR TITLE
Rubric benchmark

### DIFF
--- a/tests/benchmarks/edit_rubric_benchmark.py
+++ b/tests/benchmarks/edit_rubric_benchmark.py
@@ -1,0 +1,154 @@
+import json
+import os
+import subprocess
+from itertools import islice
+from pathlib import Path
+from textwrap import dedent
+
+import openai
+import pytest
+from git import Repo
+
+from mentat.python_client.client import PythonClient
+from tests.benchmarks.utils import clone_repo
+
+pytestmark = pytest.mark.benchmark
+
+
+@pytest.fixture
+def evaluate_baseline(request):
+    return bool(request.config.getoption("--evaluate_baseline"))
+
+
+@pytest.fixture
+def repo(request):
+    return request.config.getoption("--repo")
+
+
+def load_tests(benchmarks_dir):
+    tests = {}
+    benchmarks_path = benchmarks_dir / "benchmarks.json"
+    if benchmarks_path.exists():
+        with open(benchmarks_path, "r") as f:
+            tests = json.load(f)
+    return tests
+
+
+def load_results(benchmarks_dir):
+    results = {}
+    results_path = benchmarks_dir / "benchmark_results.json"
+    if results_path.exists():
+        with open(results_path, "r") as f:
+            results = json.load(f)
+    return results
+
+
+def write_result(commit, result, repo_path):
+    results = load_results(repo_path)
+    results[commit] = result
+    with open(repo_path / "benchmark_results.json", "w") as f:
+        json.dump(results, f, indent=4)
+
+
+grader_prompt = dedent("""\
+        Please grade the following diff on the following metrics:
+        - correctness
+        - readability
+        - style
+        - surprisingness
+        Please reply with only a json object rating the diff from 1
+        to 5 on each of those dimensions. For example:
+        {"correctness": 4, "readability": 3, "style": 2, "surprisingness": 1}
+        """)
+
+
+def evaluate_diff(diff: str) -> dict[str, int]:
+    messages = [
+        {"role": "system", "content": grader_prompt},
+        {"role": "system", "content": diff},
+    ]
+
+    response = openai.ChatCompletion.create(
+        model="gpt-4-0314",
+        messages=messages,
+    )
+
+    message = response["choices"][0]["message"]["content"]
+
+    return json.loads(message)
+
+
+@pytest.mark.asyncio
+async def test_edit_quality(
+    benchmarks, max_benchmarks, evaluate_baseline, repo, refresh_repo
+):
+    repo_path = Path(__file__).parent / f"repos/{repo}"
+    tests = load_tests(repo_path)
+    results = load_results(repo_path)
+
+    if len(benchmarks) > 0:
+        tests_to_run = {k: v for k, v in tests.items() if k in benchmarks}
+    else:
+        tests_to_run = dict(islice(tests.items(), max_benchmarks))
+
+    for test in tests_to_run.values():
+        print(f"\n\n{test['name']}\n{test['prompt']}")
+        if test["commit"] in results and not refresh_repo:
+            print("Already ran")
+            print(results[test["commit"]])
+            continue
+
+        repo_url = test["codebase_url"]
+        repo_name = repo_url.split("/")[-1]
+        codebase = clone_repo(repo_url, repo_name)
+        os.chdir(codebase)
+        with open(".git/info/exclude", "w") as f:
+            f.write(dedent("""\
+                commit_information.json
+                benchmarks.json
+                benchmark_results.json
+                transcripts*.jsonl
+                gpt-output-cache.json
+                """))
+        repo = Repo(".")
+        start_commit = repo.commit()
+        repo.git.checkout(test["commit"] + "^1")
+
+        client = PythonClient(
+            paths=test["expected_features"],
+        )
+
+        await client.startup()
+        await client.call_mentat_auto_accept(test["prompt"])
+        await client.wait_for_edit_completion()
+        await client.call_mentat("/commit")
+        # I don't think this should be necessary but without it the diff isn't
+        # ready in the next line.
+        await client.call_mentat("q")
+
+        diff = subprocess.check_output(["git", "show"]).decode("utf-8")
+        evaluation = evaluate_diff(diff)
+
+        print("Mentat produced the following diff:")
+        print(diff)
+        print("And GPT rates it in the following way:")
+        print(evaluation)
+        result = {
+            "diff": diff,
+            "grade": evaluation,
+        }
+
+        if evaluate_baseline:
+            baseline = test["expected_edits"]
+            evaluated_baseline = evaluate_diff(baseline)
+            result["baseline"] = evaluated_baseline
+            print("GPT thinks the actual diff rates:")
+            print(evaluated_baseline)
+
+        write_result(test["commit"], result, repo_path)
+
+        # Clean up
+        repo.git.reset("--hard")
+        repo.git.clean("-fd")
+        repo.git.checkout(start_commit)
+        await client.stop()

--- a/tests/benchmarks/exercism_practice.py
+++ b/tests/benchmarks/exercism_practice.py
@@ -34,11 +34,6 @@ def max_iterations(request):
 
 
 @pytest.fixture
-def refresh_repo(request):
-    return request.config.getoption("--refresh_repo")
-
-
-@pytest.fixture
 def max_workers(request):
     return int(request.config.getoption("--max_workers"))
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -78,6 +78,22 @@ def pytest_addoption(parser):
             " depends on benchmark."
         ),
     )
+    parser.addoption(
+        "--repo",
+        action="store",
+        default="mentat",
+        help="For benchmarks that are evaluated against a repo",
+    )
+    parser.addoption(
+        "--evaluate_baseline",
+        action="store_true",
+        help="Evaluate the baseline for the benchmark",
+    )
+
+
+@pytest.fixture
+def refresh_repo(request):
+    return request.config.getoption("--refresh_repo")
 
 
 @pytest.fixture


### PR DESCRIPTION

[benchmark_results.json](https://github.com/AbanteAI/mentat/files/13221332/benchmark_results.json)
[benchmarks.json](https://github.com/AbanteAI/mentat/files/13221333/benchmarks.json)

Mentat is given a repo, commit and prompt and attempts to make edits. gpt-4 grades. The actual edits can also be graded. You can generate benchmarks with `./scripts/git_log_to_transcripts.py`. You can also use the attached `benchmarks.json`. If you copy it to `tests/benchmarks/repos/mentat` (where you should clone mentat). I'd like to keep this PR small but in the future we should have:
* An html results page like for exercism
* Comparative quality benchmarks where we put both the actual and generated diffs in context. Both a version where we tell gpt which is real and one where we don't.

My first impression looking at the grading is gpt-4 overrates it's correctness. For instance in the exercism clojure benchmark runner gpt doesn't override the right methods but they aren't in context so it has no way to know. 