### PR TITLE
Fix: cli flag parsing

### DIFF
--- a/tests/config_test.py
+++ b/tests/config_test.py
@@ -34,11 +34,13 @@ async def test_config_creation():
     assert args.format is None
     assert args.use_embeddings
     assert args.auto_tokens == "2"
+    assert not args.no_code_map
 
     with open(config_file_name, "w") as project_config_file:
         project_config_file.write(dedent("""\
         {
-            "input_style": [[ "project", "yes" ]]
+            "input_style": [[ "project", "yes" ]],
+            "no_code_map": true
         }"""))
 
     mentat.config.user_config_path = Path(str(config_file_name) + "1")
@@ -57,9 +59,9 @@ async def test_config_creation():
     assert config.maximum_context == 1
     assert config.format == "replacement"
     assert config.use_embeddings
-    assert not config.no_code_map
     assert config.auto_tokens == 2
     assert config.input_style == [["project", "yes"]]
+    assert config.no_code_map
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
The boolean flags would still be set to true or false if no flag was added so settings set in the config file would be overwritten with no flag. Namespace values are now not stored if they are equal to the default.

Also I realized attrs provided a boolean converter so I removed mine.