### PR TITLE
Include paths from diff/pr-diff if no paths given

### DIFF
--- a/mentat/code_context.py
+++ b/mentat/code_context.py
@@ -107,6 +107,8 @@ class CodeContext:
         exclude_paths: list[Path],
         ignore_paths: list[Path] = [],
     ):
+        if not paths and (self.diff or self.pr_diff) and self.diff_context.files:
+            paths = self.diff_context.files
         self.include_files, invalid_paths = get_include_files(paths, exclude_paths)
         for invalid_path in invalid_paths:
             print_invalid_path(invalid_path)

--- a/mentat/session.py
+++ b/mentat/session.py
@@ -67,6 +67,8 @@ class Session:
 
         # Functions that require session_context
         config.send_errors_to_stream()
+        if not paths and (diff or pr_diff) and code_context.diff_context.files:
+            paths = code_context.diff_context.files
         code_context.set_paths(paths, exclude_paths, ignore_paths)
         code_context.set_code_map()
 

--- a/mentat/session.py
+++ b/mentat/session.py
@@ -67,8 +67,6 @@ class Session:
 
         # Functions that require session_context
         config.send_errors_to_stream()
-        if not paths and (diff or pr_diff) and code_context.diff_context.files:
-            paths = code_context.diff_context.files
         code_context.set_paths(paths, exclude_paths, ignore_paths)
         code_context.set_code_map()
 

--- a/tests/diff_context_test.py
+++ b/tests/diff_context_test.py
@@ -172,17 +172,20 @@ async def test_diff_context_end_to_end(
     # SESSION_CONTEXT isn't reset between tests
     SESSION_CONTEXT.set(None)
     mock_call_llm_api.set_generator_values([""])
-    python_client = PythonClient(["."], diff="HEAD~2")
+    python_client = PythonClient([], diff="HEAD~2")
     await python_client.startup()
 
     session_context = SESSION_CONTEXT.get()
     code_context = session_context.code_context
+    code_message = await code_context.get_code_message("test", "test", 1)
     diff_context = code_context.diff_context
 
     assert diff_context.target == "HEAD~2"
     assert diff_context.name.startswith("HEAD~2: ")
     assert diff_context.name.endswith(": add testbed")
     assert diff_context.files == [abs_path]
+
+    assert "multifile_calculator" in code_message
 
     await python_client.call_mentat("Conversation")
     await python_client.stop()


### PR DESCRIPTION
Addresses #239: Use --diff or --pr-diff to set paths if no paths arg given. We used to do this but it must've gotten lost at some point.

Another issue: If the diff/pr-diff is too big for context, it raises a MentatError but doesn't close Mentat. Seems to be a lifecycle issue - the shutdown listeners maybe not yet in place. I'd defer to @waydegg on the best way to address this. Might be related to #237 too - handling errors in the session startup phase.