### PR TITLE
Parser change midconversation

### DIFF
--- a/mentat/session.py
+++ b/mentat/session.py
@@ -48,7 +48,7 @@ class Session:
 
         code_file_manager = CodeFileManager()
 
-        conversation = Conversation(config.parser)
+        conversation = Conversation()
 
         session_context = SessionContext(
             stream,

--- a/tests/commands_test.py
+++ b/tests/commands_test.py
@@ -192,7 +192,7 @@ async def test_clear_command(
     session.stream.stop()
 
     conversation = SESSION_CONTEXT.get().conversation
-    assert len(conversation.messages) == 1
+    assert len(conversation.get_messages()) == 1
 
 
 @pytest.mark.asyncio

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -200,7 +200,7 @@ async def _mock_session_context(temp_testbed):
 
     code_file_manager = CodeFileManager()
 
-    conversation = Conversation(config.parser)
+    conversation = Conversation()
 
     session_context = SessionContext(
         stream,

--- a/tests/conversation_test.py
+++ b/tests/conversation_test.py
@@ -1,0 +1,20 @@
+from mentat.parsers.block_parser import BlockParser
+from mentat.parsers.replacement_parser import ReplacementParser
+from mentat.session_context import SESSION_CONTEXT
+
+
+def test_midconveration_parser_change(mock_session_context):
+    session_context = SESSION_CONTEXT.get()
+    config = session_context.config
+    conversation = session_context.conversation
+
+    config.parser = "block"
+    assert (
+        conversation.get_messages()[0]["content"] == BlockParser().get_system_prompt()
+    )
+
+    config.parser = "replacement"
+    assert (
+        conversation.get_messages()[0]["content"]
+        == ReplacementParser().get_system_prompt()
+    )


### PR DESCRIPTION
* A get_messages method is added to conversation that manages whether to include the system prompt.
* While incorporating @PCSwingle 's feedback to make messages private I realized the clear command accessed it directly so I added a clear method for it to use instead.