### PR TITLE
Auto context interface

### DIFF
--- a/mentat/code_context.py
+++ b/mentat/code_context.py
@@ -51,6 +51,7 @@ class CodeContext:
         # or the CodeFeatures (value) and their intervals. Redundant.
         self.include_files = {}
         self.ignore_files = set()
+        self.ctags_disabled = check_ctags_disabled()
 
     def set_paths(
         self,
@@ -91,9 +92,9 @@ class CodeContext:
             stream.send(f"{prefix}Included files: None", color="yellow")
         if config.auto_context:
             stream.send(f"{prefix}Auto-Context: Enabled", color="green")
-            if check_ctags_disabled():
+            if self.ctags_disabled:
                 stream.send(
-                    f"{prefix}Code Maps Disbled: {check_ctags_disabled()}",
+                    f"{prefix}Code Maps Disbled: {self.ctags_disabled}",
                     color="yellow",
                 )
         else:
@@ -135,7 +136,7 @@ class CodeContext:
             features_checksum = sha256("".join(feature_file_checksums))
         settings = {
             "prompt": prompt,
-            "code_map_disabled": check_ctags_disabled(),
+            "code_map_disabled": self.ctags_disabled,
             "auto_context": config.auto_context,
             "use_llm": self.use_llm,
             "diff": self.diff,
@@ -200,7 +201,7 @@ class CodeContext:
             feature_filter = DefaultFilter(
                 remaining_tokens,
                 model,
-                not (bool(check_ctags_disabled())),
+                not (bool(self.ctags_disabled)),
                 self.use_llm,
                 prompt,
                 expected_edits,
@@ -266,7 +267,7 @@ class CodeContext:
                     diff=diff_target,
                     user_included=user_included,
                 )
-                if check_ctags_disabled():
+                if self.ctags_disabled:
                     all_features.append(full_feature)
                 else:
                     _split_features = split_file_into_intervals(

--- a/mentat/code_context.py
+++ b/mentat/code_context.py
@@ -154,7 +154,6 @@ class CodeContext:
         settings = {
             "code_map": self.code_map_enabled(),
             "auto_tokens": config.auto_tokens,
-            "use_embeddings": config.use_embeddings,
             "use_llm": self.use_llm,
             "diff": self.diff,
             "pr_diff": self.pr_diff,
@@ -219,7 +218,6 @@ class CodeContext:
                 remaining_tokens,
                 model,
                 self.code_map_enabled(),
-                config.use_embeddings,
                 self.use_llm,
                 prompt,
                 expected_edits,
@@ -330,16 +328,6 @@ class CodeContext:
         level: CodeMessageLevel = CodeMessageLevel.INTERVAL,
     ) -> list[tuple[CodeFeature, float]]:
         """Return the top n features that are most similar to the query."""
-        session_context = SESSION_CONTEXT.get()
-        config = session_context.config
-        stream = session_context.stream
-
-        if not config.use_embeddings:
-            stream.send(
-                "Embeddings are disabled. Enable with `/config use_embeddings true`",
-                color="light_red",
-            )
-            return []
 
         all_features = self._get_all_features(
             level,

--- a/mentat/code_context.py
+++ b/mentat/code_context.py
@@ -190,7 +190,7 @@ class CodeContext:
             ]
         code_message += ["Code Files:\n"]
         meta_tokens = count_tokens("\n".join(code_message), model)
-        remaining_tokens = max(0, max_tokens - meta_tokens)
+        remaining_tokens = max_tokens - meta_tokens
 
         if not config.auto_context or remaining_tokens <= 0:
             self.features = self._get_include_features()

--- a/mentat/code_context.py
+++ b/mentat/code_context.py
@@ -92,7 +92,10 @@ class CodeContext:
         if config.auto_context:
             stream.send(f"{prefix}Auto-Context: Enabled", color="green")
             if check_ctags_disabled():
-                stream.send(f"{prefix}Code Maps Disbled: {check_ctags_disabled()}", color="yellow")
+                stream.send(
+                    f"{prefix}Code Maps Disbled: {check_ctags_disabled()}",
+                    color="yellow",
+                )
         else:
             stream.send(f"{prefix}Auto-Context: Disabled")
 
@@ -114,7 +117,9 @@ class CodeContext:
     _code_message: str | None = None
     _code_message_checksum: str | None = None
 
-    def _get_code_message_checksum(self, prompt: str = "", max_tokens: Optional[int] = None) -> str:
+    def _get_code_message_checksum(
+        self, prompt: str = "", max_tokens: Optional[int] = None
+    ) -> str:
         session_context = SESSION_CONTEXT.get()
         config = session_context.config
         git_root = session_context.git_root
@@ -155,7 +160,9 @@ class CodeContext:
             self._code_message = await self._get_code_message(
                 prompt, max_tokens, expected_edits
             )
-            self._code_message_checksum = self._get_code_message_checksum(prompt, max_tokens)
+            self._code_message_checksum = self._get_code_message_checksum(
+                prompt, max_tokens
+            )
         return self._code_message
 
     use_llm: bool = True
@@ -193,7 +200,7 @@ class CodeContext:
             feature_filter = DefaultFilter(
                 remaining_tokens,
                 model,
-                not(bool(check_ctags_disabled())),
+                not (bool(check_ctags_disabled())),
                 self.use_llm,
                 prompt,
                 expected_edits,

--- a/mentat/code_map.py
+++ b/mentat/code_map.py
@@ -1,18 +1,15 @@
 import json
+import logging
 import subprocess
 import tempfile
 from functools import cache
 from pathlib import Path
 from typing import Any
 
-from mentat.session_context import SESSION_CONTEXT
-
 
 def get_ctags(
     abs_file_path: Path, exclude_signatures: bool = False
 ) -> set[tuple[str | int | None, ...]]:
-    session_context = SESSION_CONTEXT.get()
-    stream = session_context.stream
 
     # Create ctags from executable in a subprocess
     ctags_cmd_args = [
@@ -38,10 +35,7 @@ def get_ctags(
         try:
             tag = json.loads(output_line)
         except json.decoder.JSONDecodeError as err:
-            stream.send(
-                f"Error parsing ctags output: {err}\n{repr(output_line)}",
-                color="yellow",
-            )
+            logging.error(f"Error parsing ctags output: {err}\n{repr(output_line)}")
             continue
 
         scope = tag.get("scope")

--- a/mentat/code_map.py
+++ b/mentat/code_map.py
@@ -10,7 +10,6 @@ from typing import Any
 def get_ctags(
     abs_file_path: Path, exclude_signatures: bool = False
 ) -> set[tuple[str | int | None, ...]]:
-
     # Create ctags from executable in a subprocess
     ctags_cmd_args = [
         "--extras=-F",

--- a/mentat/config.py
+++ b/mentat/config.py
@@ -75,17 +75,15 @@ class Config:
         default=[],
         metadata={"description": "List of glob patterns to exclude from context"},
     )
-    auto_tokens: int = attr.field(
-        default=0,
+    auto_context: bool = attr.field(
+        default=False,
         metadata={
             "description": (
-                "Maximum number of auto-generated tokens to include in the prompt"
-                " context"
+                "Automatically select code files to include in context."
             ),
             "abbreviation": "a",
         },
-        converter=int,
-        validator=validators.optional(validators.ge(0)),
+        converter=converters.optional(converters.to_bool),
     )
 
     # Only settable by config file

--- a/mentat/config.py
+++ b/mentat/config.py
@@ -75,15 +75,6 @@ class Config:
         default=[],
         metadata={"description": "List of glob patterns to exclude from context"},
     )
-    no_code_map: bool = attr.field(
-        default=False,
-        metadata={
-            "description": (
-                "Exclude the file structure/syntax map from the system prompt"
-            )
-        },
-        converter=converters.optional(converters.to_bool),
-    )
     auto_tokens: int = attr.field(
         default=0,
         metadata={

--- a/mentat/config.py
+++ b/mentat/config.py
@@ -31,6 +31,7 @@ class Config:
     # Model specific settings
     model: str = attr.field(default="gpt-4-0314")
     feature_selection_model: str = attr.field(default="gpt-4-0314")
+    embedding_model: str = attr.field(default="text-embedding-ada-002")
     temperature: float = attr.field(
         default=0.5, converter=float, validator=[validators.le(1), validators.ge(0)]
     )
@@ -73,13 +74,6 @@ class Config:
     file_exclude_glob_list: list[str] = attr.field(
         default=[],
         metadata={"description": "List of glob patterns to exclude from context"},
-    )
-    use_embeddings: bool = attr.field(
-        default=False,
-        metadata={
-            "description": "Fetch/compare embeddings to auto-generate code context"
-        },
-        converter=converters.optional(converters.to_bool),
     )
     no_code_map: bool = attr.field(
         default=False,

--- a/mentat/config.py
+++ b/mentat/config.py
@@ -78,9 +78,7 @@ class Config:
     auto_context: bool = attr.field(
         default=False,
         metadata={
-            "description": (
-                "Automatically select code files to include in context."
-            ),
+            "description": "Automatically select code files to include in context.",
             "abbreviation": "a",
         },
         converter=converters.optional(converters.to_bool),

--- a/mentat/embeddings.py
+++ b/mentat/embeddings.py
@@ -91,7 +91,9 @@ def _batch_ffd(data: dict[str, int], batch_size: int) -> list[list[str]]:
 embedding_api_semaphore = asyncio.Semaphore(MAX_SIMULTANEOUS_REQUESTS)
 
 
-async def _fetch_embeddings(model: str, batch: list[str], retries: int = 3, wait_time: int = 20):
+async def _fetch_embeddings(
+    model: str, batch: list[str], retries: int = 3, wait_time: int = 20
+):
     async with embedding_api_semaphore:
         for _ in range(retries):
             try:

--- a/mentat/feature_filters/default_filter.py
+++ b/mentat/feature_filters/default_filter.py
@@ -14,7 +14,6 @@ class DefaultFilter(FeatureFilter):
         max_tokens: int,
         model: str = "gpt-4",
         code_map: bool = False,
-        use_embeddings: bool = False,
         use_llm: bool = False,
         user_prompt: Optional[str] = None,
         expected_edits: Optional[list[str]] = None,
@@ -24,10 +23,6 @@ class DefaultFilter(FeatureFilter):
         self.code_map = code_map
         self.use_llm = use_llm
         self.user_prompt = user_prompt or ""
-        if user_prompt == "":
-            self.use_embeddings = False
-        else:
-            self.use_embeddings = use_embeddings
         self.levels = [CodeMessageLevel.FILE_NAME]
         if self.code_map:
             self.levels = [
@@ -37,7 +32,7 @@ class DefaultFilter(FeatureFilter):
         self.expected_edits = expected_edits
 
     async def filter(self, features: list[CodeFeature]) -> list[CodeFeature]:
-        if self.use_embeddings:
+        if self.user_prompt != "":
             features = await EmbeddingSimilarityFilter(self.user_prompt).filter(
                 features
             )

--- a/tests/benchmarks/context_benchmark.py
+++ b/tests/benchmarks/context_benchmark.py
@@ -111,7 +111,6 @@ async def select_features_for_benchmark(
     )
     # Fill-in available context
     config.auto_tokens = 1e6
-    config.use_embeddings = True
     code_context.use_llm = use_llm
     await code_context.get_code_message(
         benchmark["prompt"], max_context_tokens, expected_edits

--- a/tests/benchmarks/context_benchmark.py
+++ b/tests/benchmarks/context_benchmark.py
@@ -110,7 +110,7 @@ async def select_features_for_benchmark(
         model_context_size(model) - mentat_prompt_tokens - expected_edits_tokens
     )
     # Fill-in available context
-    config.auto_tokens = 1e6
+    config.auto_context = True
     code_context.use_llm = use_llm
     await code_context.get_code_message(
         benchmark["prompt"], max_context_tokens, expected_edits

--- a/tests/benchmarks/exercism_practice.py
+++ b/tests/benchmarks/exercism_practice.py
@@ -108,7 +108,7 @@ async def run_exercise(problem_dir, language="python", max_iterations=2):
     client = PythonClient(
         paths=exercise_runner.include_files(),
         exclude_paths=exercise_runner.exclude_files(),
-        config=Config(no_code_map=True),
+        config=Config(),
     )
     await client.startup()
 

--- a/tests/code_context_test.py
+++ b/tests/code_context_test.py
@@ -193,7 +193,7 @@ def features(mocker):
 
 @pytest.mark.asyncio
 async def test_get_code_message_cache(mocker, temp_testbed, mock_session_context):
-    mocker.patch.object(Config, "auto_tokens", new=10)
+    mocker.patch.object(Config, "maximum_context", new=10)
     code_context = CodeContext(
         mock_session_context.stream,
         mock_session_context.git_root,
@@ -218,8 +218,7 @@ async def test_get_code_message_cache(mocker, temp_testbed, mock_session_context
     assert value1 == value2
 
     # Regenerate if settings change
-    mocker.patch.object(Config, "auto_tokens", new=11)
-    value3 = await code_context.get_code_message(prompt="", max_tokens=1e6)
+    value3 = await code_context.get_code_message(prompt="", max_tokens=1e5)
     assert value1 != value3
 
     # Regenerate if feature files change
@@ -233,7 +232,7 @@ async def test_get_code_message_cache(mocker, temp_testbed, mock_session_context
 
 @pytest.mark.asyncio
 async def test_get_code_message_include(mocker, temp_testbed, mock_session_context):
-    mocker.patch.object(Config, "auto_tokens", new=0)
+    mocker.patch.object(Config, "maximum_context", new=0)
     code_context = CodeContext(
         mock_session_context.stream,
         mock_session_context.git_root,
@@ -264,7 +263,7 @@ async def test_get_code_message_include(mocker, temp_testbed, mock_session_conte
 
 @pytest.mark.asyncio
 @pytest.mark.clear_testbed
-async def test_auto_tokens(mocker, temp_testbed, mock_session_context):
+async def test_max_auto_tokens(mocker, temp_testbed, mock_session_context):
     with open("file_1.py", "w") as f:
         f.write(dedent("""\
             def func_1(x, y):
@@ -290,18 +289,18 @@ async def test_auto_tokens(mocker, temp_testbed, mock_session_context):
         mock_session_context.git_root,
     )
     code_context.set_paths(["file_1.py"], [])
-
-    async def _count_auto_tokens_where(limit: int) -> int:
-        mocker.patch.object(Config, "auto_tokens", new=limit)
+    code_context.use_llm = False
+    mock_session_context.config.auto_context = True
+    async def _count_max_tokens_where(limit: int) -> int:
         code_message = await code_context.get_code_message(prompt="", max_tokens=limit)
         return count_tokens(code_message, "gpt-4")
 
-    assert await _count_auto_tokens_where(1e6) == 85  # Code
-    assert await _count_auto_tokens_where(84) == 65  # Cmap w/ signatures
-    assert await _count_auto_tokens_where(60) == 57  # Cmap
-    assert await _count_auto_tokens_where(52) == 47  # fnames
+    assert await _count_max_tokens_where(1e6) == 85  # Code
+    assert await _count_max_tokens_where(84) == 65  # Cmap w/ signatures
+    assert await _count_max_tokens_where(60) == 57  # Cmap
+    assert await _count_max_tokens_where(52) == 47  # fnames
     # Always return include_files, regardless of max
-    assert await _count_auto_tokens_where(0) == 42  # Include_files only
+    assert await _count_max_tokens_where(0) == 42  # Include_files only
 
 
 @pytest.mark.clear_testbed
@@ -344,11 +343,13 @@ def test_get_all_features(temp_testbed, mock_session_context):
 
 @pytest.mark.asyncio
 async def test_get_code_message_ignore(mocker, temp_testbed, mock_session_context):
-    mocker.patch.object(Config, "auto_tokens", new=7000)
+    mock_session_context.config.auto_context = True
+    mocker.patch.object(Config, "maximum_context", new=7000)
     code_context = CodeContext(
         mock_session_context.stream,
         mock_session_context.git_root,
     )
+    code_context.use_llm = False
     code_context.set_paths([], [], ["scripts", "**/*.txt"])
     code_message = await code_context.get_code_message("", 1e6)
 

--- a/tests/code_context_test.py
+++ b/tests/code_context_test.py
@@ -291,6 +291,7 @@ async def test_max_auto_tokens(mocker, temp_testbed, mock_session_context):
     code_context.set_paths(["file_1.py"], [])
     code_context.use_llm = False
     mock_session_context.config.auto_context = True
+
     async def _count_max_tokens_where(limit: int) -> int:
         code_message = await code_context.get_code_message(prompt="", max_tokens=limit)
         return count_tokens(code_message, "gpt-4")

--- a/tests/code_file_manager_test.py
+++ b/tests/code_file_manager_test.py
@@ -45,7 +45,6 @@ async def test_partial_files(mocker, mock_session_context):
     mock_session_context.code_context.include_files, _ = get_include_files(
         [file_path_partial], []
     )
-    mocker.patch.object(Config, "auto_tokens", new=0)
     mock_session_context.code_context.code_map = False
 
     code_message = await mock_session_context.code_context.get_code_message(

--- a/tests/code_file_manager_test.py
+++ b/tests/code_file_manager_test.py
@@ -4,7 +4,6 @@ from textwrap import dedent
 
 import pytest
 
-from mentat.config import Config
 from mentat.include_files import get_include_files
 from mentat.parsers.file_edit import FileEdit, Replacement
 from mentat.session import Session

--- a/tests/config_test.py
+++ b/tests/config_test.py
@@ -25,14 +25,13 @@ async def test_config_creation():
             "--maximum-context",
             "1",
             "-a",
-            "2",
         ]
     )
     assert args.model == "model"
     assert args.temperature == 0.2
     assert args.maximum_context == "1"
     assert args.parser is None
-    assert args.auto_tokens == 2
+    assert args.auto_context is True
 
     with open(config_file_name, "w") as project_config_file:
         project_config_file.write(dedent("""\
@@ -55,7 +54,7 @@ async def test_config_creation():
     assert config.temperature == 0.2
     assert config.maximum_context == 1
     assert type(config.parser) == ReplacementParser
-    assert config.auto_tokens == 2
+    assert config.auto_context is True
     assert config.input_style == [["project", "yes"]]
 
 

--- a/tests/config_test.py
+++ b/tests/config_test.py
@@ -24,7 +24,6 @@ async def test_config_creation():
             "0.2",
             "--maximum-context",
             "1",
-            "--use-embeddings",
             "-a",
             "2",
         ]
@@ -33,7 +32,6 @@ async def test_config_creation():
     assert args.temperature == 0.2
     assert args.maximum_context == "1"
     assert args.parser is None
-    assert args.use_embeddings
     assert args.auto_tokens == 2
     assert not args.no_code_map
 
@@ -59,7 +57,6 @@ async def test_config_creation():
     assert config.temperature == 0.2
     assert config.maximum_context == 1
     assert type(config.parser) == ReplacementParser
-    assert config.use_embeddings
     assert config.auto_tokens == 2
     assert config.input_style == [["project", "yes"]]
     assert config.no_code_map

--- a/tests/config_test.py
+++ b/tests/config_test.py
@@ -33,13 +33,11 @@ async def test_config_creation():
     assert args.maximum_context == "1"
     assert args.parser is None
     assert args.auto_tokens == 2
-    assert not args.no_code_map
 
     with open(config_file_name, "w") as project_config_file:
         project_config_file.write(dedent("""\
         {
-            "input_style": [[ "project", "yes" ]],
-            "no_code_map": true
+            "input_style": [[ "project", "yes" ]]
         }"""))
 
     mentat.config.user_config_path = Path(str(config_file_name) + "1")
@@ -59,7 +57,6 @@ async def test_config_creation():
     assert type(config.parser) == ReplacementParser
     assert config.auto_tokens == 2
     assert config.input_style == [["project", "yes"]]
-    assert config.no_code_map
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
This PR consolidates a lot of args and settings related to context.

Removed:
- use_embeddings (always on)
- no_code_map (always try to use)
- auto_tokens (config.maximum_context achieves the same thing)

Added:
- auto_context: bool = False (use cmaps, embeddings and llm to generate the best possible context)

I leave `CodeContext.use_llm` and set it to True by default. This is currently used by tests so that we can test filter behavior without calling the LLM.