### PR TITLE
Default temperature changed to 0.05

### DIFF
--- a/mentat/config.py
+++ b/mentat/config.py
@@ -33,7 +33,7 @@ class Config:
     feature_selection_model: str = attr.field(default="gpt-4-0314")
     embedding_model: str = attr.field(default="text-embedding-ada-002")
     temperature: float = attr.field(
-        default=0.05, converter=float, validator=[validators.le(1), validators.ge(0)]
+        default=0.2, converter=float, validator=[validators.le(1), validators.ge(0)]
     )
 
     maximum_context: int | None = attr.field(

--- a/mentat/config.py
+++ b/mentat/config.py
@@ -33,7 +33,7 @@ class Config:
     feature_selection_model: str = attr.field(default="gpt-4-0314")
     embedding_model: str = attr.field(default="text-embedding-ada-002")
     temperature: float = attr.field(
-        default=0.5, converter=float, validator=[validators.le(1), validators.ge(0)]
+        default=0.05, converter=float, validator=[validators.le(1), validators.ge(0)]
     )
 
     maximum_context: int | None = attr.field(


### PR DESCRIPTION
In benchmarks smaller temperature settings were always associated with improvements in performance. This is the smallest value I tested.