### PR TITLE
Auto Tokens re-added

### DIFF
--- a/mentat/code_context.py
+++ b/mentat/code_context.py
@@ -166,7 +166,7 @@ class CodeContext:
             )
         return self._code_message
 
-    use_llm: bool = True
+    use_llm: bool = False
 
     async def _get_code_message(
         self,
@@ -190,7 +190,8 @@ class CodeContext:
             ]
         code_message += ["Code Files:\n"]
         meta_tokens = count_tokens("\n".join(code_message), model)
-        remaining_tokens = max_tokens - meta_tokens
+        auto_tokens = config.auto_tokens
+        remaining_tokens = min(max_tokens, auto_tokens) - meta_tokens
 
         if not config.auto_context or remaining_tokens <= 0:
             self.features = self._get_include_features()

--- a/mentat/config.py
+++ b/mentat/config.py
@@ -83,6 +83,17 @@ class Config:
         },
         converter=converters.optional(converters.to_bool),
     )
+    auto_tokens: int = attr.field(
+        default=3000,
+        metadata={
+            "description": (
+                "Maximum number of auto-generated tokens to include in the prompt"
+                " context"
+            ),
+        },
+        converter=int,
+        validator=validators.optional(validators.ge(0)),
+    )
 
     # Only settable by config file
     input_style: list[tuple[str, str]] = attr.field(


### PR DESCRIPTION
We should not use the LLMs max context as our limit for auto context as it may be unreasonably large. A setting is readded to limit it. Use LLM is also set to false as it doesn't have guards for context length.