### PR TITLE
Fix Git subprocess calls to suppress error output

### DIFF
--- a/mentat/git_handler.py
+++ b/mentat/git_handler.py
@@ -7,14 +7,6 @@ from mentat.errors import UserError
 from mentat.session_context import SESSION_CONTEXT
 
 
-def get_git_diff_for_path(path: Path) -> str:
-    session_context = SESSION_CONTEXT.get()
-    git_root = session_context.git_root
-    return subprocess.check_output(
-        ["git", "diff", path], cwd=git_root, text=True, stderr=subprocess.DEVNULL
-    )
-
-
 def get_non_gitignored_files(path: Path) -> set[Path]:
     return set(
         # git returns / separated paths even on windows, convert so we can remove

--- a/mentat/git_handler.py
+++ b/mentat/git_handler.py
@@ -10,7 +10,7 @@ from mentat.session_context import SESSION_CONTEXT
 def get_git_diff_for_path(path: Path) -> str:
     session_context = SESSION_CONTEXT.get()
     git_root = session_context.git_root
-    return subprocess.check_output(["git", "diff", path], cwd=git_root, text=True)
+    return subprocess.check_output(["git", "diff", path], cwd=git_root, text=True, stderr=subprocess.DEVNULL)
 
 
 def get_non_gitignored_files(path: Path) -> set[Path]:
@@ -25,6 +25,7 @@ def get_non_gitignored_files(path: Path) -> set[Path]:
                 ["git", "ls-files", "-c", "-o", "--exclude-standard"],
                 cwd=path,
                 text=True,
+                stderr=subprocess.DEVNULL,
             ).split("\n"),
         )
     )
@@ -35,10 +36,10 @@ def get_paths_with_git_diffs() -> set[Path]:
     git_root = session_context.git_root
 
     changed = subprocess.check_output(
-        ["git", "diff", "--name-only"], cwd=git_root, text=True
+        ["git", "diff", "--name-only"], cwd=git_root, text=True, stderr=subprocess.DEVNULL
     ).split("\n")
     new = subprocess.check_output(
-        ["git", "ls-files", "-o", "--exclude-standard"], cwd=git_root, text=True
+        ["git", "ls-files", "-o", "--exclude-standard"], cwd=git_root, text=True, stderr=subprocess.DEVNULL
     ).split("\n")
     return set(
         map(
@@ -69,9 +70,7 @@ def _get_git_root_for_path(path: Path) -> Path:
         )
         # --show-toplevel doesn't work in some windows environment with posix paths,
         # like msys2, so we have to use --show-prefix instead
-        git_root = os.path.abspath(
-            os.path.join(dir_path, "../" * len(Path(relative_path).parts))
-        )
+        git_root = os.path.abspath(os.path.join(dir_path, "../" * len(Path(relative_path).parts)))
         # call realpath to resolve symlinks, so all paths match
         return Path(os.path.realpath(git_root))
     except subprocess.CalledProcessError:
@@ -89,10 +88,7 @@ def get_shared_git_root_for_paths(paths: list[Path]) -> Path:
         git_roots.add(git_root)
 
     if len(git_roots) > 1:
-        logging.error(
-            "All paths must be part of the same git project! Projects provided:"
-            f" {git_roots}"
-        )
+        logging.error("All paths must be part of the same git project! Projects provided:" f" {git_roots}")
         raise UserError()
     elif len(git_roots) == 0:
         logging.error("No git projects provided.")
@@ -116,7 +112,7 @@ def get_diff_for_file(target: str, path: Path) -> str:
 
     try:
         diff_content = subprocess.check_output(
-            ["git", "diff", "-U0", f"{target}", "--", path], cwd=git_root, text=True
+            ["git", "diff", "-U0", f"{target}", "--", path], cwd=git_root, text=True, stderr=subprocess.DEVNULL
         ).strip()
         return diff_content
     except subprocess.CalledProcessError:
@@ -130,6 +126,7 @@ def get_treeish_metadata(git_root: Path, target: str) -> dict[str, str]:
             ["git", "log", target, "-n", "1", "--pretty=format:%H %s"],
             cwd=git_root,
             text=True,
+            stderr=subprocess.DEVNULL,
         ).strip()
 
         # Split the returned string into the hash and summary
@@ -147,7 +144,7 @@ def get_files_in_diff(target: str) -> list[Path]:
 
     try:
         diff_content = subprocess.check_output(
-            ["git", "diff", "--name-only", f"{target}", "--"], cwd=git_root, text=True
+            ["git", "diff", "--name-only", f"{target}", "--"], cwd=git_root, text=True, stderr=subprocess.DEVNULL
         ).strip()
         if diff_content:
             return [Path(path) for path in diff_content.split("\n")]
@@ -163,7 +160,7 @@ def check_head_exists() -> bool:
     git_root = session_context.git_root
 
     try:
-        subprocess.check_output(["git", "rev-parse", "HEAD", "--"], cwd=git_root)
+        subprocess.check_output(["git", "rev-parse", "HEAD", "--"], cwd=git_root, stderr=subprocess.DEVNULL)
         return True
     except subprocess.CalledProcessError:
         return False
@@ -176,7 +173,7 @@ def get_default_branch() -> str:
     try:
         # Fetch the symbolic ref of HEAD which points to the default branch
         default_branch = subprocess.check_output(
-            ["git", "rev-parse", "--abbrev-ref", "HEAD"], cwd=git_root, text=True
+            ["git", "rev-parse", "--abbrev-ref", "HEAD"], cwd=git_root, text=True, stderr=subprocess.DEVNULL
         ).strip()
         return default_branch
     except subprocess.CalledProcessError:

--- a/mentat/git_handler.py
+++ b/mentat/git_handler.py
@@ -10,7 +10,9 @@ from mentat.session_context import SESSION_CONTEXT
 def get_git_diff_for_path(path: Path) -> str:
     session_context = SESSION_CONTEXT.get()
     git_root = session_context.git_root
-    return subprocess.check_output(["git", "diff", path], cwd=git_root, text=True, stderr=subprocess.DEVNULL)
+    return subprocess.check_output(
+        ["git", "diff", path], cwd=git_root, text=True, stderr=subprocess.DEVNULL
+    )
 
 
 def get_non_gitignored_files(path: Path) -> set[Path]:
@@ -36,10 +38,16 @@ def get_paths_with_git_diffs() -> set[Path]:
     git_root = session_context.git_root
 
     changed = subprocess.check_output(
-        ["git", "diff", "--name-only"], cwd=git_root, text=True, stderr=subprocess.DEVNULL
+        ["git", "diff", "--name-only"],
+        cwd=git_root,
+        text=True,
+        stderr=subprocess.DEVNULL,
     ).split("\n")
     new = subprocess.check_output(
-        ["git", "ls-files", "-o", "--exclude-standard"], cwd=git_root, text=True, stderr=subprocess.DEVNULL
+        ["git", "ls-files", "-o", "--exclude-standard"],
+        cwd=git_root,
+        text=True,
+        stderr=subprocess.DEVNULL,
     ).split("\n")
     return set(
         map(
@@ -70,7 +78,9 @@ def _get_git_root_for_path(path: Path) -> Path:
         )
         # --show-toplevel doesn't work in some windows environment with posix paths,
         # like msys2, so we have to use --show-prefix instead
-        git_root = os.path.abspath(os.path.join(dir_path, "../" * len(Path(relative_path).parts)))
+        git_root = os.path.abspath(
+            os.path.join(dir_path, "../" * len(Path(relative_path).parts))
+        )
         # call realpath to resolve symlinks, so all paths match
         return Path(os.path.realpath(git_root))
     except subprocess.CalledProcessError:
@@ -88,7 +98,10 @@ def get_shared_git_root_for_paths(paths: list[Path]) -> Path:
         git_roots.add(git_root)
 
     if len(git_roots) > 1:
-        logging.error("All paths must be part of the same git project! Projects provided:" f" {git_roots}")
+        logging.error(
+            "All paths must be part of the same git project! Projects provided:"
+            f" {git_roots}"
+        )
         raise UserError()
     elif len(git_roots) == 0:
         logging.error("No git projects provided.")
@@ -112,7 +125,10 @@ def get_diff_for_file(target: str, path: Path) -> str:
 
     try:
         diff_content = subprocess.check_output(
-            ["git", "diff", "-U0", f"{target}", "--", path], cwd=git_root, text=True, stderr=subprocess.DEVNULL
+            ["git", "diff", "-U0", f"{target}", "--", path],
+            cwd=git_root,
+            text=True,
+            stderr=subprocess.DEVNULL,
         ).strip()
         return diff_content
     except subprocess.CalledProcessError:
@@ -144,7 +160,10 @@ def get_files_in_diff(target: str) -> list[Path]:
 
     try:
         diff_content = subprocess.check_output(
-            ["git", "diff", "--name-only", f"{target}", "--"], cwd=git_root, text=True, stderr=subprocess.DEVNULL
+            ["git", "diff", "--name-only", f"{target}", "--"],
+            cwd=git_root,
+            text=True,
+            stderr=subprocess.DEVNULL,
         ).strip()
         if diff_content:
             return [Path(path) for path in diff_content.split("\n")]
@@ -160,7 +179,9 @@ def check_head_exists() -> bool:
     git_root = session_context.git_root
 
     try:
-        subprocess.check_output(["git", "rev-parse", "HEAD", "--"], cwd=git_root, stderr=subprocess.DEVNULL)
+        subprocess.check_output(
+            ["git", "rev-parse", "HEAD", "--"], cwd=git_root, stderr=subprocess.DEVNULL
+        )
         return True
     except subprocess.CalledProcessError:
         return False
@@ -173,7 +194,10 @@ def get_default_branch() -> str:
     try:
         # Fetch the symbolic ref of HEAD which points to the default branch
         default_branch = subprocess.check_output(
-            ["git", "rev-parse", "--abbrev-ref", "HEAD"], cwd=git_root, text=True, stderr=subprocess.DEVNULL
+            ["git", "rev-parse", "--abbrev-ref", "HEAD"],
+            cwd=git_root,
+            text=True,
+            stderr=subprocess.DEVNULL,
         ).strip()
         return default_branch
     except subprocess.CalledProcessError:


### PR DESCRIPTION
Silence all subprocess STDERR output from git subprocess calls. If there is an error, an exception will be thrown. We don't rely on STDERR for anything, and atm the Terminal Client gets a bunch of console output for git errors even though we already handle that w/ Exception try-catch blocks.

*This PR is part of a series of PRs to remove `git_root` from Mentat, and allow Sessions to be run anywhere on the filesystem.*



