### PR TITLE
Remove `SESSION_CONTEXT.git_root` from `DiffContext`

### DIFF
--- a/mentat/diff_context.py
+++ b/mentat/diff_context.py
@@ -142,12 +142,13 @@ class DiffContext:
     @property
     def files(self) -> list[Path]:
         session_context = SESSION_CONTEXT.get()
-        git_root = session_context.git_root
 
         if self._files_cache is None:
             if self.target == "HEAD" and not check_head_exists():
                 return []  # A new repo without any commits
-            self._files_cache = [git_root / f for f in get_files_in_diff(self.target)]
+            self._files_cache = [
+                session_context.cwd / f for f in get_files_in_diff(self.target)
+            ]
         return self._files_cache
 
     _annotations_cache: dict[Path, list[DiffAnnotation]] = {}

--- a/tests/diff_context_test.py
+++ b/tests/diff_context_test.py
@@ -172,7 +172,7 @@ async def test_diff_context_end_to_end(
     # SESSION_CONTEXT isn't reset between tests
     SESSION_CONTEXT.set(None)
     mock_call_llm_api.set_generator_values([""])
-    python_client = PythonClient(paths=[], diff="HEAD~2")
+    python_client = PythonClient(cwd=temp_testbed, paths=[], diff="HEAD~2")
     await python_client.startup()
 
     session_context = SESSION_CONTEXT.get()


### PR DESCRIPTION
*This PR is part of a series of PRs to remove `git_root` from Mentat, and allow Sessions to be run anywhere on the filesystem.*