### PR TITLE
fix errors in vscode pyright linter

### DIFF
--- a/mentat/code_feature.py
+++ b/mentat/code_feature.py
@@ -36,13 +36,11 @@ def split_file_into_intervals(
 
     # Get ctags data (name and start line) and determine end line
     ctags = list(get_ctags(git_root.joinpath(feature.path)))
-    ctags = sorted(ctags, key=lambda x: int(x[4]))  # type: ignore
+    ctags.sort(key=lambda x: int(x[4]))
     named_intervals = list[tuple[str, int, int]]()  # Name, Start, End
     _last_item = tuple[str, int]()
     for i, tag in enumerate(ctags):
         (scope, _, name, _, line_number) = tag  # Kind and Signature ignored
-        if name is None or line_number is None:
-            continue
         key = name
         if scope is not None:
             key = f"{scope}.{name}"

--- a/mentat/code_map.py
+++ b/mentat/code_map.py
@@ -44,7 +44,6 @@ def get_ctags(abs_file_path: Path, exclude_signatures: bool = False):
         line_number: int = tag.get("line")
 
         ctags.add((scope, kind, name, signature, line_number))
-        print((scope, kind, name, signature, line_number))
     return ctags
 
 

--- a/mentat/code_map.py
+++ b/mentat/code_map.py
@@ -6,10 +6,10 @@ from functools import cache
 from pathlib import Path
 from typing import Any
 
+CTAG = tuple[str | None, str, str, str | None, int]
 
-def get_ctags(
-    abs_file_path: Path, exclude_signatures: bool = False
-) -> set[tuple[str | int | None, ...]]:
+
+def get_ctags(abs_file_path: Path, exclude_signatures: bool = False):
     # Create ctags from executable in a subprocess
     ctags_cmd_args = [
         "--extras=-F",
@@ -29,7 +29,7 @@ def get_ctags(
     output_lines = output.splitlines()
 
     # Extract subprocess stdout into python objects
-    ctags = set[tuple[str | int | None, ...]]()
+    ctags = set[CTAG]()
     for output_line in output_lines:
         try:
             tag = json.loads(output_line)
@@ -37,18 +37,18 @@ def get_ctags(
             logging.error(f"Error parsing ctags output: {err}\n{repr(output_line)}")
             continue
 
-        scope = tag.get("scope")
-        kind = tag.get("kind")
-        name = tag.get("name")
-        signature = tag.get("signature")
-        line_number = tag.get("line")
+        scope: str | None = tag.get("scope")
+        kind: str = tag.get("kind")
+        name: str = tag.get("name")
+        signature: str | None = tag.get("signature")
+        line_number: int = tag.get("line")
 
         ctags.add((scope, kind, name, signature, line_number))
-
+        print((scope, kind, name, signature, line_number))
     return ctags
 
 
-def _make_ctags_human_readable(ctags: set[tuple[Any, ...]]) -> list[str]:
+def _make_ctags_human_readable(ctags: set[CTAG]) -> list[str]:
     cleaned_tags = set[tuple[str, ...]]()
     for tag in ctags:
         (scope, kind, name, signature, _) = tag  # Line number currently unused

--- a/mentat/code_map.py
+++ b/mentat/code_map.py
@@ -9,7 +9,7 @@ from typing import Any
 CTAG = tuple[str | None, str, str, str | None, int]
 
 
-def get_ctags(abs_file_path: Path, exclude_signatures: bool = False):
+def get_ctags(abs_file_path: Path, exclude_signatures: bool = False) -> set[CTAG]:
     # Create ctags from executable in a subprocess
     ctags_cmd_args = [
         "--extras=-F",

--- a/mentat/config.py
+++ b/mentat/config.py
@@ -26,7 +26,7 @@ def int_or_none(s: str | None) -> int | None:
 
 @attr.define
 class Config:
-    _errors: list[str] = attr.field(default=[])
+    _errors: list[str] = attr.field(factory=list)
 
     # Model specific settings
     model: str = attr.field(default="gpt-4-0314")
@@ -72,7 +72,7 @@ class Config:
 
     # Context specific settings
     file_exclude_glob_list: list[str] = attr.field(
-        default=[],
+        factory=list,
         metadata={"description": "List of glob patterns to exclude from context"},
     )
     auto_context: bool = attr.field(
@@ -86,7 +86,7 @@ class Config:
 
     # Only settable by config file
     input_style: list[tuple[str, str]] = attr.field(
-        default=[
+        factory=lambda: [
             ["", "#9835bd"],
             ["prompt", "#ffffff bold"],
             ["continuation", "#ffffff bold"],


### PR DESCRIPTION
@granawkins I added a new CTAG type; you were previously checking for if line number or name was None; in my own testing I couldn't find anywhere where it would've been None, but I don't have much experience with ctags. Do you know if it can ever be None?