### PR TITLE
gpt-4-turbo default, rate limit message

### DIFF
--- a/mentat/config.py
+++ b/mentat/config.py
@@ -29,8 +29,8 @@ class Config:
     _errors: list[str] = attr.field(default=[])
 
     # Model specific settings
-    model: str = attr.field(default="gpt-4-0314")
-    feature_selection_model: str = attr.field(default="gpt-4-0314")
+    model: str = attr.field(default="gpt-4-1106-preview")
+    feature_selection_model: str = attr.field(default="gpt-4-1106-preview")
     embedding_model: str = attr.field(default="text-embedding-ada-002")
     temperature: float = attr.field(
         default=0.2, converter=float, validator=[validators.le(1), validators.ge(0)]

--- a/mentat/conversation.py
+++ b/mentat/conversation.py
@@ -186,7 +186,7 @@ class Conversation:
         except RateLimitError:
             stream.send(
                 "Rate limit recieved from OpenAI's servers using model"
-                f" {config.model}.\nUse /config model <model_name> to switch to a"
+                f' {config.model}.\nUse "/config model <model_name>" to switch to a'
                 " different model.",
                 color="light_red",
             )

--- a/mentat/llm_api.py
+++ b/mentat/llm_api.py
@@ -98,7 +98,7 @@ def warn_user(message: str, max_tries: int, details: Details):
     exception=RateLimitError,
     max_tries=3,
     base=2,
-    factor=10,
+    factor=5,
     jitter=None,
     logger="",
     giveup_log_level=logging.INFO,

--- a/mentat/session.py
+++ b/mentat/session.py
@@ -9,6 +9,7 @@ from uuid import uuid4
 
 import attr
 import sentry_sdk
+from openai import InvalidRequestError
 from openai.error import RateLimitError, Timeout
 
 from mentat.code_context import CodeContext
@@ -121,7 +122,7 @@ class Session:
                 stream.send(bool(file_edits), channel="edits_complete")
         except SessionExit:
             pass
-        except (Timeout, RateLimitError) as e:
+        except (Timeout, RateLimitError, InvalidRequestError) as e:
             stream.send(f"Error accessing OpenAI API: {str(e)}", color="red")
 
     async def listen_for_session_exit(self):

--- a/tests/commands_test.py
+++ b/tests/commands_test.py
@@ -240,7 +240,7 @@ async def test_config_command(mock_session_context):
     await command.apply("test")
     assert stream.messages[-1].data == "Unrecognized config option: test"
     await command.apply("model")
-    assert stream.messages[-1].data == "model: gpt-4-0314"
+    assert stream.messages[-1].data.startswith("model: ")
     await command.apply("model", "test")
     assert stream.messages[-1].data == "model set to test"
     assert config.model == "test"


### PR DESCRIPTION
Rather than add a model 'waterfall', I decided to leave control in the user's hands and just give a warning that they should use /config model <model_name>. I also set gpt-4 turbo as the default model.
![image](https://github.com/AbanteAI/mentat/assets/18667262/4de5f483-c71e-43d0-b094-1d67a4f33683)
