### PR TITLE
Benchmark runner and simple benchmark added

### DIFF
--- a/tests/benchmarks/benchmark_runner.py
+++ b/tests/benchmarks/benchmark_runner.py
@@ -1,0 +1,94 @@
+import importlib.util
+import os
+
+import pytest
+from git import Repo
+
+from mentat.config import Config
+from mentat.python_client.client import PythonClient
+from tests.benchmarks.utils import clone_repo
+
+
+def dynamic_import(path_to_module, module_name):
+    spec = importlib.util.spec_from_file_location(module_name, path_to_module)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+pytestmark = pytest.mark.benchmark
+
+
+@pytest.fixture
+def retries(request):
+    return int(request.config.getoption("--retries"))
+
+
+@pytest.mark.asyncio
+async def test_benchmark(retries):
+    print("Running benchmarks")
+    benchmarks_dir = f"{os.path.dirname(__file__)}/benchmarks"
+
+    benchmark_paths = []
+    for root, dirs, files in os.walk(benchmarks_dir):
+        for file in files:
+            if file.endswith(".py"):
+                benchmark_paths.append(os.path.join(root, file))
+
+    print("Found benchmarks:", " ".join(benchmark_paths))
+    results = {}
+    for path in benchmark_paths:
+        benchmark = dynamic_import(path, "benchmark")
+        print("Benchmark:", benchmark.title)
+        results[benchmark.title] = {}
+
+        codebase = clone_repo(
+            url=benchmark.repo,
+            local_dir_name=benchmark.repo.split("/")[-1],
+            refresh=False,
+        )
+
+        os.chdir(codebase)
+        repo = Repo(".")
+        start_commit = repo.commit()
+        repo.git.checkout(benchmark.commit)
+
+        for prompt in benchmark.prompts:
+            print("  Prompt:", prompt)
+            for i in range(1, retries + 1):
+                client = PythonClient(
+                    config=Config(
+                        auto_context=True,
+                        maximum_context=8000,
+                    )
+                )
+
+                await client.startup()
+                await client.call_mentat_auto_accept(prompt)
+                await client.wait_for_edit_completion()
+                await client.call_mentat("q")
+                await client.shutdown()
+
+                success = benchmark.verify()
+
+                repo.git.reset("--hard")
+                repo.git.clean("-fd")
+                if success:
+                    print("  Passed")
+                    results[benchmark.title][prompt] = {
+                        "Passed": True,
+                        "Attempts": i,
+                    }
+                    break
+                else:
+                    if i == retries:
+                        print("  Failed")
+                        results[benchmark.title][prompt] = {
+                            "Passed": False,
+                            "Attempts": i,
+                        }
+                    else:
+                        print(f"  Failed on {i}th attempt")
+
+        repo.git.checkout(start_commit)
+    print(results)

--- a/tests/benchmarks/benchmarks/mentat/license_update.py
+++ b/tests/benchmarks/benchmarks/mentat/license_update.py
@@ -1,0 +1,45 @@
+import importlib
+
+title = "License Update"
+
+description = """
+This benchmark tests the ability of Mentat to add a license to the allowed license list.
+"""
+
+prompts = [
+    # This one fails too by not putting HPND second. But it was the only prompt
+    # I could make that consistently passes verify.
+    'Add "HPND" second in the list of allowed licenses.',
+    # This one generally fails with an off by one error. Putting HPND
+    # outside of the list.
+    'Add "HPND" to the list of allowed licenses.',
+    # About half the time GPT spells out Historical Permission Notice and Disclaimer
+    "Add HPND to the list of allowed licenses.",
+]
+
+repo = "https://github.com/AbanteAI/mentat"
+commit = "b0848711c36e0c2fe9619ebb2b77dc6d27396ff2"
+minimum_context = ["tests/license_check.py:11-22"]
+
+
+def verify():
+    try:
+        import tests.benchmarks.repos.mentat.tests.license_check as license_check
+
+        importlib.reload(license_check)
+        return set(license_check.accepted_licenses) == set(
+            [
+                "BSD License",
+                "Apache Software License",
+                "MIT License",
+                "MIT",
+                "Mozilla Public License 2.0 (MPL 2.0)",
+                "Python Software Foundation License",
+                "Apache 2.0",
+                "BSD 3-Clause",
+                "ISC License (ISCL)",
+                "HPND",
+            ]
+        )
+    except IndentationError:
+        return False

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -44,6 +44,12 @@ def pytest_addoption(parser):
         help="The maximum number of exercises to run",
     )
     parser.addoption(
+        "--retries",
+        action="store",
+        default="1",
+        help="Number of times to retry a benchmark",
+    )
+    parser.addoption(
         "--max_iterations",
         action="store",
         default="1",


### PR DESCRIPTION
This represents a break from how I was thinking about benchmarks previously:
* Rather than generating many benchmarks it'll likely be more valuable to have a few that we can understand well.
* If we're going to write or understand them by hand I'd much prefer to have them in python than json.
  - It'll be easy to convert the json tests into this format when we are ready for generated tests.
* Similar to how pytest discovers test files I think our benchmark runner should discover benchmarks in the benchmark directory.
* For simple benchmarks we should have a deterministic test to see if gpt succeeded which is what I've done for this one test.
* When I introduce a more complicated benchmark I'll add GPT grading with a hand made context for the task.
* Part of what makes a task challenging is the ambiguity of the prompt so I wrote multiple versions. The first mostly succeeds. The second two maybe 50-50.

Run with:
```
pytest tests/benchmarks/benchmark_runner.py --benchmark -s --retries 2
```