### PR TITLE
add auto-tokens argument back

### DIFF
--- a/mentat/code_context.py
+++ b/mentat/code_context.py
@@ -92,6 +92,7 @@ class CodeContext:
             stream.send(f"{prefix}Included files: None", color="yellow")
         if config.auto_context:
             stream.send(f"{prefix}Auto-Context: Enabled", color="green")
+            stream.send(f"{prefix}Auto-Tokens: {config.auto_tokens}")
             if self.ctags_disabled:
                 stream.send(
                     f"{prefix}Code Maps Disbled: {self.ctags_disabled}",
@@ -193,15 +194,16 @@ class CodeContext:
         code_message += ["Code Files:\n"]
         meta_tokens = count_tokens("\n".join(code_message), model, full_message=True)
         remaining_tokens = max_tokens - meta_tokens
+        auto_tokens = min(remaining_tokens, config.auto_tokens)
 
-        if not config.auto_context or remaining_tokens <= 0:
+        if not config.auto_context or auto_tokens <= 0:
             self.features = self._get_include_features()
         else:
             self.features = self._get_all_features(
                 CodeMessageLevel.INTERVAL,
             )
             feature_filter = DefaultFilter(
-                remaining_tokens,
+                auto_tokens,
                 not (bool(self.ctags_disabled)),
                 self.use_llm,
                 prompt,

--- a/mentat/config.py
+++ b/mentat/config.py
@@ -84,7 +84,7 @@ class Config:
         converter=converters.optional(converters.to_bool),
     )
     auto_tokens: int = attr.field(
-        default=4000,
+        default=8000,
         metadata={
             "description": "The number of tokens auto-context can add.",
         },

--- a/mentat/config.py
+++ b/mentat/config.py
@@ -83,6 +83,13 @@ class Config:
         },
         converter=converters.optional(converters.to_bool),
     )
+    auto_tokens: int = attr.field(
+        default=4000,
+        metadata={
+            "description": "The number of tokens auto-context can add.",
+        },
+        converter=int,
+    )
 
     # Only settable by config file
     input_style: list[tuple[str, str]] = attr.field(

--- a/mentat/config.py
+++ b/mentat/config.py
@@ -86,7 +86,7 @@ class Config:
     auto_tokens: int = attr.field(
         default=8000,
         metadata={
-            "description": "The number of tokens auto-context can add.",
+            "description": "The number of tokens auto-context will add.",
         },
         converter=int,
     )


### PR DESCRIPTION
Short PR to add the `auto-tokens` arg back, with a default of 4000, which applies only to additional files added by `auto-context`, as discussed.

This is quite necessary now that `gpt-4-1103` is the default model, so I'm doing a tiny PR to fast-track it.