### PR TITLE
Add file to context if it really exits but could not be expanded by glob, which is the case of pages/[slug]/index.tsx or simillar pattern, common in nextjs

### DIFF
--- a/mentat/include_files.py
+++ b/mentat/include_files.py
@@ -18,6 +18,8 @@ def expand_paths(paths: list[Path]) -> tuple[list[Path], list[str]]:
         new_paths = glob.glob(pathname=str(path), recursive=True)
         if new_paths:
             globbed_paths.update(new_paths)
+        elif Path(path).exists():
+            globbed_paths.add(str(path))
         else:
             split = str(path).rsplit(":", 1)
             p = Path(split[0])
@@ -28,8 +30,6 @@ def expand_paths(paths: list[Path]) -> tuple[list[Path], list[str]]:
             if Path(p).exists() and intervals:
                 for interval in intervals:
                     globbed_paths.add(f"{p}:{interval.start}-{interval.end}")
-            elif Path(p).exists():
-                globbed_paths.add(str(p))
             else:
                 invalid_paths.add(str(path))
     return [Path(path).resolve() for path in globbed_paths], list(invalid_paths)

--- a/mentat/include_files.py
+++ b/mentat/include_files.py
@@ -28,6 +28,8 @@ def expand_paths(paths: list[Path]) -> tuple[list[Path], list[str]]:
             if Path(p).exists() and intervals:
                 for interval in intervals:
                     globbed_paths.add(f"{p}:{interval.start}-{interval.end}")
+            elif Path(p).exists():
+                globbed_paths.add(str(p))
             else:
                 invalid_paths.add(str(path))
     return [Path(path).resolve() for path in globbed_paths], list(invalid_paths)

--- a/tests/code_context_test.py
+++ b/tests/code_context_test.py
@@ -51,6 +51,32 @@ async def test_path_gitignoring(temp_testbed, mock_session_context):
 
 
 @pytest.mark.asyncio
+async def test_bracket_file(temp_testbed, mock_session_context):
+    file_path_1 = Path("[file].tsx")
+    file_path_2 = Path("test:[file].tsx")
+
+    with file_path_1.open("w") as file_1:
+        file_1.write("Testing")
+    with file_path_2.open("w") as file_2:
+        file_2.write("Testing")
+
+    paths = [file_path_1, file_path_2]
+    code_context = CodeContext(
+        mock_session_context.stream,
+        mock_session_context.git_root,
+    )
+    code_context.set_paths(paths, [])
+    expected_file_paths = [
+        temp_testbed / file_path_1,
+        temp_testbed / file_path_2,
+    ]
+
+    case = TestCase()
+    file_paths = list(code_context.include_files.keys())
+    case.assertListEqual(sorted(expected_file_paths), sorted(file_paths))
+
+
+@pytest.mark.asyncio
 async def test_config_glob_exclude(mocker, temp_testbed, mock_session_context):
     # Makes sure glob exclude config works
     mocker.patch.object(


### PR DESCRIPTION
I was getting errors when trying to include files like `[that].tsx` (yes, this is allowed)

This commit fixes it