### PR TITLE
Add inspiration comment to code_map.py

### DIFF
--- a/mentat/code_map.py
+++ b/mentat/code_map.py
@@ -1,3 +1,6 @@
+# Our code map implementation was inspired by Aider's repo map, which also uses ctags to create a map of a project.
+# Aider: https://github.com/paul-gauthier/aider
+
 import json
 import logging
 import subprocess


### PR DESCRIPTION
Adds attribution comment to the top of `code_map.py`, linked to Aider. The original PR implementing this code (https://github.com/AbanteAI/mentat/pull/66) referenced Aider as inspiration but it should be in the code as well.

Resolves #302 