### PR TITLE
change no changes applied message

### DIFF
--- a/mentat/code_edit_feedback.py
+++ b/mentat/code_edit_feedback.py
@@ -61,11 +61,7 @@ async def get_user_feedback_on_edits(
             conversation.add_message(
                 ChatCompletionSystemMessageParam(
                     role="system",
-                    content=(
-                        "User chose not to apply any of your changes. Please adjust"
-                        " your previous plan and changes to reflect their feedback."
-                        " Respond with a full new set of changes."
-                    ),
+                    content="User chose not to apply any of your changes.",
                 )
             )
             conversation.add_user_message(user_response)


### PR DESCRIPTION
I found that the model was much better at answering whether or not it's changes were applied (without being given access to the files to see if they were applied) with this wording.