### PR TITLE
Browser reopened if closed

### DIFF
--- a/mentat/session.py
+++ b/mentat/session.py
@@ -180,7 +180,9 @@ class Session:
 
         session_context = SESSION_CONTEXT.get()
         cost_tracker = session_context.cost_tracker
+        vision_manager = session_context.vision_manager
 
+        vision_manager.close()
         cost_tracker.display_total_cost()
         logging.shutdown()
         self._exit_task.cancel()


### PR DESCRIPTION
Currently an exception is thrown if the user closes the browser and tries to take another screenshot. According to Chat GPT this is the best way to tell if the browser is still open.

The browser is also closed when the session ends.