### PR TITLE
dont use non existent files in checksum

### DIFF
--- a/mentat/code_context.py
+++ b/mentat/code_context.py
@@ -130,7 +130,9 @@ class CodeContext:
         if not self.features:
             features_checksum = ""
         else:
-            feature_files = {Path(git_root / f.path) for f in self.features}
+            feature_files = {
+                git_root / f.path for f in self.features if (git_root / f.path).exists()
+            }
             feature_file_checksums = [
                 code_file_manager.get_file_checksum(f) for f in feature_files
             ]


### PR DESCRIPTION
Fixes #296. @granawkins the reason this was crashing was because we try to read the file when determining the checksum for the features, and the features aren't changed when the include files are changed. Before merging this, I think we should have the exclude_files function exclude files from features as well; I wanted to ask you though since this is your code.