### PR TITLE
Auto context issues

### DIFF
--- a/mentat/code_edit_feedback.py
+++ b/mentat/code_edit_feedback.py
@@ -22,6 +22,7 @@ async def get_user_feedback_on_edits(
     user_response = user_response_message.data
 
     need_user_request = True
+    total_changes = sum([len(file_edit.replacements) for file_edit in file_edits])
     match user_response.lower():
         case "y" | "":
             edits_to_apply = file_edits
@@ -70,8 +71,15 @@ async def get_user_feedback_on_edits(
         file_edit.resolve_conflicts()
 
     if edits_to_apply:
-        await code_file_manager.write_changes_to_files(edits_to_apply, code_context)
-        stream.send("Changes applied.", color="light_blue")
+        applied_edits = await code_file_manager.write_changes_to_files(
+            edits_to_apply, code_context
+        )
+        applied_changes = sum(
+            [len(file_edit.replacements) or 1 for file_edit in applied_edits]
+        )
+        stream.send(
+            f"{applied_changes}/{total_changes} changes applied.", color="light_blue"
+        )
     else:
         stream.send("No changes applied.", color="light_blue")
 

--- a/mentat/code_edit_feedback.py
+++ b/mentat/code_edit_feedback.py
@@ -22,7 +22,6 @@ async def get_user_feedback_on_edits(
     user_response = user_response_message.data
 
     need_user_request = True
-    total_changes = sum([len(file_edit.replacements) or 1 for file_edit in file_edits])
     match user_response.lower():
         case "y" | "":
             edits_to_apply = file_edits
@@ -69,20 +68,15 @@ async def get_user_feedback_on_edits(
 
     for file_edit in edits_to_apply:
         file_edit.resolve_conflicts()
-
+    
+    applied_edits = []
     if edits_to_apply:
         applied_edits = await code_file_manager.write_changes_to_files(
             edits_to_apply, code_context
         )
-        applied_changes = sum(
-            [len(file_edit.replacements) or 1 for file_edit in applied_edits]
-        )
-        stream.send(
-            f"{applied_changes}/{total_changes} changes applied.", color="light_blue"
-        )
-    else:
-        stream.send("No changes applied.", color="light_blue")
-
+    message = "Changes applied." if applied_edits else "No changes applied."
+    stream.send(message, color="light_blue")
+    
     if need_user_request:
         stream.send("Can I do anything else for you?", color="light_blue")
 

--- a/mentat/code_edit_feedback.py
+++ b/mentat/code_edit_feedback.py
@@ -68,7 +68,7 @@ async def get_user_feedback_on_edits(
 
     for file_edit in edits_to_apply:
         file_edit.resolve_conflicts()
-    
+
     applied_edits = []
     if edits_to_apply:
         applied_edits = await code_file_manager.write_changes_to_files(
@@ -76,7 +76,7 @@ async def get_user_feedback_on_edits(
         )
     message = "Changes applied." if applied_edits else "No changes applied."
     stream.send(message, color="light_blue")
-    
+
     if need_user_request:
         stream.send("Can I do anything else for you?", color="light_blue")
 

--- a/mentat/code_edit_feedback.py
+++ b/mentat/code_edit_feedback.py
@@ -22,7 +22,7 @@ async def get_user_feedback_on_edits(
     user_response = user_response_message.data
 
     need_user_request = True
-    total_changes = sum([len(file_edit.replacements) for file_edit in file_edits])
+    total_changes = sum([len(file_edit.replacements) or 1 for file_edit in file_edits])
     match user_response.lower():
         case "y" | "":
             edits_to_apply = file_edits

--- a/mentat/code_file_manager.py
+++ b/mentat/code_file_manager.py
@@ -66,11 +66,12 @@ class CodeFileManager:
         self,
         file_edits: list[FileEdit],
         code_context: CodeContext,
-    ):
+    ) -> list[FileEdit]:
         session_context = SESSION_CONTEXT.get()
         stream = session_context.stream
         git_root = session_context.git_root
 
+        applied_edits: list[FileEdit] = []
         for file_edit in file_edits:
             rel_path = Path(os.path.relpath(file_edit.file_path, git_root))
             if file_edit.is_creation:
@@ -97,6 +98,7 @@ class CodeFileManager:
                         )
                     )
                     self._delete_file(code_context, file_edit.file_path)
+                    applied_edits.append(file_edit)
                     continue
                 else:
                     stream.send(f"Not deleting {rel_path}", color="green")
@@ -140,7 +142,9 @@ class CodeFileManager:
                 )
                 with open(file_edit.file_path, "w") as f:
                     f.write("\n".join(new_lines))
+            applied_edits.append(file_edit)
         self.history.push_edits()
+        return applied_edits
 
     def get_file_checksum(self, path: Path, interval: Interval | None = None) -> str:
         if path.is_dir():

--- a/mentat/interval.py
+++ b/mentat/interval.py
@@ -23,7 +23,7 @@ class Interval:
     end: int | float = attr.field()
 
     def contains(self, line_number: int):
-        return self.start <= line_number <= self.end
+        return self.start <= line_number < self.end
 
     def intersects(self, other: Interval) -> bool:
         return not (other.end < self.start or self.end < other.start)

--- a/mentat/llm_api_handler.py
+++ b/mentat/llm_api_handler.py
@@ -173,8 +173,7 @@ class LlmApiHandler:
         model: str,
         stream: Literal[True],
         response_format: ResponseFormat = ResponseFormat(type="text"),
-    ) -> AsyncStream[ChatCompletionChunk]:
-        ...
+    ) -> AsyncStream[ChatCompletionChunk]: ...
 
     @overload
     async def call_llm_api(
@@ -183,8 +182,7 @@ class LlmApiHandler:
         model: str,
         stream: Literal[False],
         response_format: ResponseFormat = ResponseFormat(type="text"),
-    ) -> ChatCompletion:
-        ...
+    ) -> ChatCompletion: ...
 
     async def call_llm_api(
         self,

--- a/mentat/llm_api_handler.py
+++ b/mentat/llm_api_handler.py
@@ -173,7 +173,8 @@ class LlmApiHandler:
         model: str,
         stream: Literal[True],
         response_format: ResponseFormat = ResponseFormat(type="text"),
-    ) -> AsyncStream[ChatCompletionChunk]: ...
+    ) -> AsyncStream[ChatCompletionChunk]:
+        ...
 
     @overload
     async def call_llm_api(
@@ -182,7 +183,8 @@ class LlmApiHandler:
         model: str,
         stream: Literal[False],
         response_format: ResponseFormat = ResponseFormat(type="text"),
-    ) -> ChatCompletion: ...
+    ) -> ChatCompletion:
+        ...
 
     async def call_llm_api(
         self,

--- a/tests/code_file_manager_test.py
+++ b/tests/code_file_manager_test.py
@@ -40,7 +40,7 @@ async def test_partial_files(mocker, mock_session_context):
              fourth
              fifth"""))
 
-    file_path_partial = file_path + ":1,3-5"
+    file_path_partial = file_path + ":1-2,3-6"
     mock_session_context.code_context.include_files, _ = get_include_files(
         [file_path_partial], []
     )


### PR DESCRIPTION
- #316 Calculate and stream `{n_applied}/{n_total} changes applied.` instead.
- #293 Make intervals inclusive-start, exclusive-end.*

\*This changes the interface (you'll see the test) so you need to specify e.g. `myfile.py:1-2` in order to include just line 1. We already do some preprocessing of these command-line args (splitting intervals into different features), so we could add a transformation to keep the cli-arg end-inclusive like they were. Thoughts?