### PR TITLE
Fix tests that failed on my laptop

### DIFF
--- a/tests/diff_context_test.py
+++ b/tests/diff_context_test.py
@@ -35,6 +35,16 @@ def git_history(temp_testbed):
     test_branch (from commit2)
       'commit4'
     """
+    # sometimes the testbed is set up with main, sometimes master,
+    # so we just make sure it's master for the tests
+    branch_name = (
+        subprocess.check_output(["git", "branch"], cwd=temp_testbed, text=True)
+        .split()[1]
+        .strip()
+    )
+    if branch_name != "master":
+        subprocess.run(["git", "checkout", "-b", "master"], cwd=temp_testbed)
+
     _update_ops(temp_testbed, "commit2", "commit2")
     _update_ops(temp_testbed, "commit3", "commit3")
     subprocess.run(["git", "checkout", "HEAD~1"], cwd=temp_testbed)


### PR DESCRIPTION
For whatever reason (git version?) some of these tests failed when I ran locally as it expected master but had main as the default branch. With this update they work on my machine and still work on Github actions too (hopefully, we'll see)