### PR TITLE
pass prompt to get_code_message as a string

### DIFF
--- a/mentat/conversation.py
+++ b/mentat/conversation.py
@@ -243,7 +243,9 @@ class Conversation:
         try:
             prompt = messages_snapshot[-1]["content"]
             if isinstance(prompt, list):
-                text_prompts = [p.get("text", "") for p in prompt if p.get("type") == "text"]
+                text_prompts = [
+                    p.get("text", "") for p in prompt if p.get("type") == "text"
+                ]
                 prompt = " ".join(text_prompts)
             code_message = await code_context.get_code_message(
                 (

--- a/mentat/conversation.py
+++ b/mentat/conversation.py
@@ -242,6 +242,9 @@ class Conversation:
         loading_multiplier = 1.0 if config.auto_context else 0.0
         try:
             prompt = messages_snapshot[-1]["content"]
+            if isinstance(prompt, list):
+                text_prompts = [p.get("text", "") for p in prompt if p.get("type") == "text"]
+                prompt = " ".join(text_prompts)
             code_message = await code_context.get_code_message(
                 (
                     # Prompt can be image as well as text


### PR DESCRIPTION
Patch for the Vision update - we should still pass a prompt string to get_code_message.