### PR TITLE
Initialize client not mocked in benchmarks

### DIFF
--- a/mentat/llm_api_handler.py
+++ b/mentat/llm_api_handler.py
@@ -148,7 +148,7 @@ def model_price_per_1000_tokens(model: str) -> Optional[tuple[float, float]]:
 class LlmApiHandler:
     """Used for any functions that require calling the external LLM API"""
 
-    def initizalize_client(self):
+    def initialize_client(self):
         if not load_dotenv(mentat_dir_path / ".env"):
             load_dotenv()
         key = os.getenv("OPENAI_API_KEY")

--- a/mentat/session.py
+++ b/mentat/session.py
@@ -102,7 +102,7 @@ class Session:
         conversation = session_context.conversation
         llm_api_handler = session_context.llm_api_handler
 
-        llm_api_handler.initizalize_client()
+        llm_api_handler.initialize_client()
         code_context.display_context()
         await conversation.display_token_count()
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -237,8 +237,9 @@ def mock_model_available(mocker):
 
 
 @pytest.fixture(autouse=True, scope="function")
-def mock_initizalize_client(mocker):
-    mocker.patch.object(LlmApiHandler, "initizalize_client")
+def mock_initizalize_client(mocker, request):
+    if not request.config.getoption("--benchmark"):
+        mocker.patch.object(LlmApiHandler, "initialize_client")
 
 
 # ContextVars need to be set in a synchronous fixture due to pytest not propagating

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -237,7 +237,7 @@ def mock_model_available(mocker):
 
 
 @pytest.fixture(autouse=True, scope="function")
-def mock_initizalize_client(mocker, request):
+def mock_initialize_client(mocker, request):
     if not request.config.getoption("--benchmark"):
         mocker.patch.object(LlmApiHandler, "initialize_client")
 


### PR DESCRIPTION
If we're in a benchmark we need to initialize the client. While I was there I fixed a typo.