### PR TITLE
Remove ipdb from dev-requirements.txt

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,7 +1,6 @@
 aiomultiprocess==0.9.0
 black==23.9.1
 gitpython==3.1.37
-ipdb==0.13.13
 isort==5.12.0
 pip-licenses==4.3.3
 pyright==1.1.336


### PR DESCRIPTION
Not required for development and ipython (an ipdb dependecy) keeps conflicting with our pinned prompt toolkit version.