### PR TITLE
add pre tags so whitespace isnt collapsed

### DIFF
--- a/mentat/resources/templates/conversation_viewer.css
+++ b/mentat/resources/templates/conversation_viewer.css
@@ -17,6 +17,7 @@ h1 {
 
 pre {
     margin: 0;
+    white-space: pre-wrap;
 }
 
 .container {

--- a/mentat/resources/templates/conversation_viewer.css
+++ b/mentat/resources/templates/conversation_viewer.css
@@ -15,6 +15,10 @@ h1 {
     margin: 10 0px;
 }
 
+pre {
+    margin: 0;
+}
+
 .container {
     position: relative;
     width: 100%;

--- a/mentat/resources/templates/conversation_viewer.jinja
+++ b/mentat/resources/templates/conversation_viewer.jinja
@@ -1,10 +1,10 @@
 {% macro display_message(message, content_key) %}
 {% if message[content_key] is string %}
-    {{ message[content_key] |e|replace('\n', '<br>')|safe }}
+    <pre>{{ message[content_key] }}</pre>
 {% else %}
     {% for submessage in message[content_key] %}
         {% if submessage["type"] == "text" %}
-            {{ submessage["text"] |e|replace('\n', '<br>')|safe }}
+            <pre>{{ submessage["text"] }}</pre>
         {% elif submessage["type"] == "image_url" %}
             <img src="{{ submessage['image_url']['url'] }}">
         {% endif %}


### PR DESCRIPTION
Fixed #342. Use \<pre\> tags to display text so whitespace appears normally; this always means we don't need to replace newlines with \<br\> tags.