### PR TITLE
Bugfix: completions don't work when Mentat run in subdirectory

### DIFF
--- a/mentat/terminal/prompt_completer.py
+++ b/mentat/terminal/prompt_completer.py
@@ -39,6 +39,11 @@ class MentatCompleter(Completer):
 
     def refresh_completions_for_file_path(self, file_path: Path):
         """Add/edit/delete completions for some filepath"""
+
+        # paths are relative to the git root, but Mentat may be run in subdirectory
+        git_root = SESSION_CONTEXT.get().git_root
+        file_path = git_root / file_path
+
         try:
             with open(file_path, "r") as f:
                 file_content = f.read()


### PR DESCRIPTION
When you ran in a subdirectory, completions (for function/class names) didn't pop up. I found this was due to using paths relative to the git root. When the mis-pathed files couldn't be opened we were calling `logging.debug(f"Skipping {file_path}. Reason: file not found")`

Fixes #317 