### PR TITLE
Sample command

### DIFF
--- a/mentat/command/commands/__init__.py
+++ b/mentat/command/commands/__init__.py
@@ -7,12 +7,12 @@ from .commit import CommitCommand
 from .config import ConfigCommand
 from .context import ContextCommand
 from .conversation import ConversationCommand
-from .example import ExampleCommand
 from .exclude import ExcludeCommand
 from .help import HelpCommand
 from .include import IncludeCommand
 from .redo import RedoCommand
 from .run import RunCommand
+from .sample import SampleCommand
 from .screenshot import ScreenshotCommand
 from .search import SearchCommand
 from .undo import UndoCommand

--- a/mentat/command/commands/__init__.py
+++ b/mentat/command/commands/__init__.py
@@ -7,6 +7,7 @@ from .commit import CommitCommand
 from .config import ConfigCommand
 from .context import ContextCommand
 from .conversation import ConversationCommand
+from .example import ExampleCommand
 from .exclude import ExcludeCommand
 from .help import HelpCommand
 from .include import IncludeCommand

--- a/mentat/command/commands/__init__.py
+++ b/mentat/command/commands/__init__.py
@@ -10,6 +10,7 @@ from .conversation import ConversationCommand
 from .exclude import ExcludeCommand
 from .help import HelpCommand
 from .include import IncludeCommand
+from .redo import RedoCommand
 from .run import RunCommand
 from .screenshot import ScreenshotCommand
 from .search import SearchCommand

--- a/mentat/command/commands/example.py
+++ b/mentat/command/commands/example.py
@@ -1,0 +1,104 @@
+import datetime
+import json
+from pathlib import Path
+
+from mentat.code_feature import get_consolidated_feature_refs
+from mentat.command.command import Command
+from mentat.git_handler import get_diff_for_file, get_paths_with_git_diffs
+from mentat.session_context import SESSION_CONTEXT
+
+
+class ExampleCommand(Command, command_name="example"):
+    async def apply(self, *args: str) -> None:
+        from mentat.parsers.git_parser import GitParser
+        from mentat.session_input import collect_user_input
+
+        session_context = SESSION_CONTEXT.get()
+        stream = session_context.stream
+        code_context = session_context.code_context
+        code_file_manager = session_context.code_file_manager
+        conversation = session_context.conversation
+
+        # Code Repo
+        stream.send("Enter github url (default AbanteAI/mentat): ", color="light_blue")
+        url = (
+            await collect_user_input()
+        ).data.strip() or "https://github.com/AbanteAI/mentat"
+
+        # Commit (should be latest on MAIN to avoid squash merge issues)
+        stream.send(
+            "Enter starting diff target (default upstream/main): ", color="light_blue"
+        )
+        commit = (await collect_user_input()).data.strip() or "upstream/main"
+
+        # Config: Items which are different from the default
+        included_features = [
+            f for fs in code_context.include_files.values() for f in fs
+        ]
+        include_files = get_consolidated_feature_refs(included_features)
+
+        # Convo: Transcript of conversation (without system prompt + context)
+        messages = [
+            m for m in conversation.get_messages() if m["role"] in {"user", "assistant"}
+        ]  # TODO Extract original prompt, or rewrite?
+
+        # Accepted changes to the code
+        errors = code_file_manager.history.undo()
+        assert not errors, f"Errors while undoing: {errors}"
+        code_edits = code_file_manager.history.undone_edits[-1].copy()
+
+        # Context: Files/lines which were used to understand and make edits
+        file_refs = {
+            edit.file_path
+            for edit in code_edits
+            if (edit.is_deletion or edit.rename_file_path or len(edit.replacements) > 0)
+        }
+
+        # Diff of commit to pre-edited code
+        changed_files = get_paths_with_git_diffs(commit)
+        diff: list[str] = []
+        for file in changed_files:
+            git_diff = get_diff_for_file(commit, file)
+            if git_diff:
+                diff += git_diff.split("\n")
+            else:
+                # Generate diff-like output for new files
+                diff += [
+                    f"diff --git a/{file} b/{file}",
+                    "new file mode 100644",
+                    "--- /dev/null",
+                    f"+++ b/{file}",
+                    "@@ -0,0 +1 @@",
+                ] + [f"+{line}" for line in file.read_text().split("\n")]
+        if diff:
+            diff_edits = GitParser().parse_string("\n".join(diff))
+        else:
+            diff_edits = []
+
+        await code_file_manager.history.redo()
+
+        example = {
+            "repo": url,
+            "commit": commit,
+            "config": [str(f) for f in include_files],
+            "convo": messages,
+            "edits": [edit.to_json() for edit in code_edits],
+            "context": [str(f) for f in file_refs],
+            "diff": diff_edits,
+        }
+
+        fname = f"example_{datetime.datetime.now().strftime('%Y-%m-%d_%H-%M-%S')}.json"
+        with open(fname, "w") as f:
+            json.dump(example, f, indent=4)
+        fpath = Path(fname).resolve()
+        assert fpath
+
+    @classmethod
+    def argument_names(cls) -> list[str]:
+        return []
+
+    @classmethod
+    def help_message(cls) -> str:
+        return (
+            "Generates a .json file containing complete record of current interaction"
+        )

--- a/mentat/command/commands/redo.py
+++ b/mentat/command/commands/redo.py
@@ -1,0 +1,22 @@
+from mentat.command.command import Command
+from mentat.session_context import SESSION_CONTEXT
+
+
+class RedoCommand(Command, command_name="redo"):
+    async def apply(self, *args: str) -> None:
+        session_context = SESSION_CONTEXT.get()
+        stream = session_context.stream
+        code_file_manager = session_context.code_file_manager
+
+        errors = await code_file_manager.history.redo()
+        if errors:
+            stream.send(errors)
+        stream.send("Redo complete", color="green")
+
+    @classmethod
+    def argument_names(cls) -> list[str]:
+        return []
+
+    @classmethod
+    def help_message(cls) -> str:
+        return "Redo the last change made by Mentat"

--- a/mentat/command/commands/sample.py
+++ b/mentat/command/commands/sample.py
@@ -8,7 +8,7 @@ from mentat.git_handler import get_diff_for_file, get_paths_with_git_diffs
 from mentat.session_context import SESSION_CONTEXT
 
 
-class ExampleCommand(Command, command_name="example"):
+class SampleCommand(Command, command_name="sample"):
     async def apply(self, *args: str) -> None:
         from mentat.parsers.git_parser import GitParser
         from mentat.session_input import collect_user_input
@@ -77,7 +77,7 @@ class ExampleCommand(Command, command_name="example"):
 
         await code_file_manager.history.redo()
 
-        example = {
+        sample = {
             "repo": url,
             "commit": commit,
             "config": [str(f) for f in include_files],
@@ -87,9 +87,9 @@ class ExampleCommand(Command, command_name="example"):
             "diff": diff_edits,
         }
 
-        fname = f"example_{datetime.datetime.now().strftime('%Y-%m-%d_%H-%M-%S')}.json"
+        fname = f"sample_{datetime.datetime.now().strftime('%Y-%m-%d_%H-%M-%S')}.json"
         with open(fname, "w") as f:
-            json.dump(example, f, indent=4)
+            json.dump(sample, f, indent=4)
         fpath = Path(fname).resolve()
         assert fpath
 

--- a/mentat/command/commands/sample.py
+++ b/mentat/command/commands/sample.py
@@ -1,97 +1,20 @@
 import datetime
-import json
-from pathlib import Path
 
-from mentat.code_feature import get_consolidated_feature_refs
 from mentat.command.command import Command
-from mentat.git_handler import get_diff_for_file, get_paths_with_git_diffs
 from mentat.session_context import SESSION_CONTEXT
 
 
 class SampleCommand(Command, command_name="sample"):
     async def apply(self, *args: str) -> None:
-        from mentat.parsers.git_parser import GitParser
-        from mentat.session_input import collect_user_input
+        from mentat.sample import Sample
 
         session_context = SESSION_CONTEXT.get()
         stream = session_context.stream
-        code_context = session_context.code_context
-        code_file_manager = session_context.code_file_manager
-        conversation = session_context.conversation
 
-        # Code Repo
-        stream.send("Enter github url (default AbanteAI/mentat): ", color="light_blue")
-        url = (
-            await collect_user_input()
-        ).data.strip() or "https://github.com/AbanteAI/mentat"
-
-        # Commit (should be latest on MAIN to avoid squash merge issues)
-        stream.send(
-            "Enter starting diff target (default upstream/main): ", color="light_blue"
-        )
-        commit = (await collect_user_input()).data.strip() or "upstream/main"
-
-        # Config: Items which are different from the default
-        included_features = [
-            f for fs in code_context.include_files.values() for f in fs
-        ]
-        include_files = get_consolidated_feature_refs(included_features)
-
-        # Convo: Transcript of conversation (without system prompt + context)
-        messages = [
-            m for m in conversation.get_messages() if m["role"] in {"user", "assistant"}
-        ]  # TODO Extract original prompt, or rewrite?
-
-        # Accepted changes to the code
-        errors = code_file_manager.history.undo()
-        assert not errors, f"Errors while undoing: {errors}"
-        code_edits = code_file_manager.history.undone_edits[-1].copy()
-
-        # Context: Files/lines which were used to understand and make edits
-        file_refs = {
-            edit.file_path
-            for edit in code_edits
-            if (edit.is_deletion or edit.rename_file_path or len(edit.replacements) > 0)
-        }
-
-        # Diff of commit to pre-edited code
-        changed_files = get_paths_with_git_diffs(commit)
-        diff: list[str] = []
-        for file in changed_files:
-            git_diff = get_diff_for_file(commit, file)
-            if git_diff:
-                diff += git_diff.split("\n")
-            else:
-                # Generate diff-like output for new files
-                diff += [
-                    f"diff --git a/{file} b/{file}",
-                    "new file mode 100644",
-                    "--- /dev/null",
-                    f"+++ b/{file}",
-                    "@@ -0,0 +1 @@",
-                ] + [f"+{line}" for line in file.read_text().split("\n")]
-        if diff:
-            diff_edits = GitParser().parse_string("\n".join(diff))
-        else:
-            diff_edits = []
-
-        await code_file_manager.history.redo()
-
-        sample = {
-            "repo": url,
-            "commit": commit,
-            "config": [str(f) for f in include_files],
-            "convo": messages,
-            "edits": [edit.to_json() for edit in code_edits],
-            "context": [str(f) for f in file_refs],
-            "diff": diff_edits,
-        }
-
-        fname = f"sample_{datetime.datetime.now().strftime('%Y-%m-%d_%H-%M-%S')}.json"
-        with open(fname, "w") as f:
-            json.dump(sample, f, indent=4)
-        fpath = Path(fname).resolve()
-        assert fpath
+        sample = await Sample.from_context(session_context)
+        timestamp = datetime.datetime.now().strftime("%Y-%m-%d_%H-%M-%S")
+        sample.save(f"sample_{timestamp}.json")
+        stream.send("Sample saved to file.", color="light_blue")
 
     @classmethod
     def argument_names(cls) -> list[str]:

--- a/mentat/config.py
+++ b/mentat/config.py
@@ -100,6 +100,10 @@ class Config:
         converter=int,
     )
 
+    # Sample specific settings
+    sample_repo: str = attr.field(default=None)
+    sample_merge_base: str = attr.field(default=None)
+
     # Only settable by config file
     input_style: list[tuple[str, str]] = attr.field(
         factory=lambda: [

--- a/mentat/edit_history.py
+++ b/mentat/edit_history.py
@@ -3,6 +3,11 @@ from pathlib import Path
 
 import attr
 from termcolor import colored
+from typing import Optional
+
+from mentat.errors import MentatError
+from mentat.parsers.file_edit import FileEdit, Replacement
+from mentat.session_context import SESSION_CONTEXT
 
 
 # All paths should be abs paths
@@ -11,29 +16,34 @@ class RenameAction:
     old_file_name: Path = attr.field()
     cur_file_name: Path = attr.field()
 
-    def undo(self) -> str | None:
+    def undo(self) -> FileEdit:
         if self.old_file_name.exists():
-            return colored(
-                f"File {self.old_file_name} already exists; unable to undo rename from"
-                f" {self.cur_file_name}",
-                color="light_red",
+            raise MentatError(
+                f"File {self.old_file_name} already exists; unable to undo rename from {self.cur_file_name}"
             )
         else:
             os.rename(self.cur_file_name, self.old_file_name)
+            return FileEdit(
+                file_path=self.old_file_name,
+                rename_file_path=self.cur_file_name
+            )
 
 
 @attr.define()
 class CreationAction:
     cur_file_name: Path = attr.field()
 
-    def undo(self) -> str | None:
+    def undo(self) -> FileEdit:
         if not self.cur_file_name.exists():
-            return colored(
-                f"File {self.cur_file_name} does not exist; unable to delete",
-                color="light_red",
+            raise MentatError(
+                f"File {self.cur_file_name} does not exist; unable to delete"
             )
         else:
             self.cur_file_name.unlink()
+            return FileEdit(
+                file_path=self.cur_file_name,
+                is_creation=True
+            )
 
 
 @attr.define()
@@ -41,15 +51,18 @@ class DeletionAction:
     old_file_name: Path = attr.field()
     old_file_lines: list[str] = attr.field()
 
-    def undo(self) -> str | None:
+    def undo(self) -> FileEdit:
         if self.old_file_name.exists():
-            return colored(
-                f"File {self.old_file_name} already exists; unable to re-create",
-                color="light_red",
+            raise MentatError(
+                f"File {self.old_file_name} already exists; unable to re-create"
             )
         else:
             with open(self.old_file_name, "w") as f:
                 f.write("\n".join(self.old_file_lines))
+            return FileEdit(
+                file_path=self.old_file_name,
+                is_deletion=True
+            )
 
 
 @attr.define()
@@ -57,15 +70,23 @@ class EditAction:
     cur_file_name: Path = attr.field()
     old_file_lines: list[str] = attr.field()
 
-    def undo(self) -> str | None:
+    def undo(self) -> FileEdit:
         if not self.cur_file_name.exists():
-            return colored(
-                f"File {self.cur_file_name} does not exist; unable to undo edit",
-                color="light_red",
+            raise MentatError(
+                f"File {self.cur_file_name} does not exist; unable to undo edit"
             )
         else:
+            new_file_lines = self.cur_file_name.read_text().split("\n")
             with open(self.cur_file_name, "w") as f:
                 f.write("\n".join(self.old_file_lines))
+            return FileEdit(
+                file_path=self.cur_file_name,
+                replacements=[Replacement(
+                    starting_line=0,
+                    ending_line=len(self.old_file_lines),
+                    new_lines=new_file_lines
+                )]
+            )
 
 
 HistoryAction = RenameAction | CreationAction | DeletionAction | EditAction
@@ -76,6 +97,7 @@ class EditHistory:
     def __init__(self):
         self.edits = list[list[HistoryAction]]()
         self.cur_edit = list[HistoryAction]()
+        self.undone_edits = list[list[FileEdit]]()
 
     def add_action(self, history_action: HistoryAction):
         self.cur_edit.append(history_action)
@@ -93,12 +115,31 @@ class EditHistory:
         # Make sure to go top down
         cur_edit = self.edits.pop()
         errors = list[str]()
+        undone_edit = list[FileEdit]()
         while cur_edit:
             cur_action = cur_edit.pop()
-            error = cur_action.undo()
-            if error is not None:
-                errors.append(error)
+            try:
+                redo_edit = cur_action.undo()
+                undone_edit.append(redo_edit)
+            except MentatError as e:
+                errors.append(colored(str(e), color="light_red"))
+        if undone_edit:
+            self.undone_edits.append(undone_edit)
         return "\n".join(errors)
+
+    async def redo(self) -> Optional[str]:
+        if not self.undone_edits:
+            return colored("No edits available to redo", color="light_red")
+        
+        session_context = SESSION_CONTEXT.get()
+        code_file_manager = session_context.code_file_manager
+        code_context = session_context.code_context
+
+        edits_to_redo = self.undone_edits.pop()
+        edits_to_redo.reverse()
+        await code_file_manager.write_changes_to_files(
+            edits_to_redo, code_context
+        )
 
     def undo_all(self) -> str:
         if not self.edits:

--- a/mentat/edit_history.py
+++ b/mentat/edit_history.py
@@ -103,7 +103,6 @@ class EditHistory:
             self.edits.append(self.cur_edit)
             self.cur_edit = list[HistoryAction]()
 
-    # TODO: Add redo
     def undo(self) -> str:
         if not self.edits:
             return colored("No edits available to undo", color="light_red")

--- a/mentat/edit_history.py
+++ b/mentat/edit_history.py
@@ -1,9 +1,9 @@
 import os
 from pathlib import Path
+from typing import Optional
 
 import attr
 from termcolor import colored
-from typing import Optional
 
 from mentat.errors import MentatError
 from mentat.parsers.file_edit import FileEdit, Replacement
@@ -19,13 +19,13 @@ class RenameAction:
     def undo(self) -> FileEdit:
         if self.old_file_name.exists():
             raise MentatError(
-                f"File {self.old_file_name} already exists; unable to undo rename from {self.cur_file_name}"
+                f"File {self.old_file_name} already exists; unable to undo rename from"
+                f" {self.cur_file_name}"
             )
         else:
             os.rename(self.cur_file_name, self.old_file_name)
             return FileEdit(
-                file_path=self.old_file_name,
-                rename_file_path=self.cur_file_name
+                file_path=self.old_file_name, rename_file_path=self.cur_file_name
             )
 
 
@@ -40,10 +40,7 @@ class CreationAction:
             )
         else:
             self.cur_file_name.unlink()
-            return FileEdit(
-                file_path=self.cur_file_name,
-                is_creation=True
-            )
+            return FileEdit(file_path=self.cur_file_name, is_creation=True)
 
 
 @attr.define()
@@ -59,10 +56,7 @@ class DeletionAction:
         else:
             with open(self.old_file_name, "w") as f:
                 f.write("\n".join(self.old_file_lines))
-            return FileEdit(
-                file_path=self.old_file_name,
-                is_deletion=True
-            )
+            return FileEdit(file_path=self.old_file_name, is_deletion=True)
 
 
 @attr.define()
@@ -81,11 +75,13 @@ class EditAction:
                 f.write("\n".join(self.old_file_lines))
             return FileEdit(
                 file_path=self.cur_file_name,
-                replacements=[Replacement(
-                    starting_line=0,
-                    ending_line=len(self.old_file_lines),
-                    new_lines=new_file_lines
-                )]
+                replacements=[
+                    Replacement(
+                        starting_line=0,
+                        ending_line=len(self.old_file_lines),
+                        new_lines=new_file_lines,
+                    )
+                ],
             )
 
 
@@ -130,16 +126,14 @@ class EditHistory:
     async def redo(self) -> Optional[str]:
         if not self.undone_edits:
             return colored("No edits available to redo", color="light_red")
-        
+
         session_context = SESSION_CONTEXT.get()
         code_file_manager = session_context.code_file_manager
         code_context = session_context.code_context
 
         edits_to_redo = self.undone_edits.pop()
         edits_to_redo.reverse()
-        await code_file_manager.write_changes_to_files(
-            edits_to_redo, code_context
-        )
+        await code_file_manager.write_changes_to_files(edits_to_redo, code_context)
 
     def undo_all(self) -> str:
         if not self.edits:

--- a/mentat/git_handler.py
+++ b/mentat/git_handler.py
@@ -27,12 +27,12 @@ def get_non_gitignored_files(path: Path) -> set[Path]:
     )
 
 
-def get_paths_with_git_diffs() -> set[Path]:
+def get_paths_with_git_diffs(target: str = "HEAD") -> set[Path]:
     session_context = SESSION_CONTEXT.get()
     git_root = session_context.git_root
 
     changed = subprocess.check_output(
-        ["git", "diff", "--name-only"],
+        ["git", "diff", "--name-only", target],
         cwd=git_root,
         text=True,
         stderr=subprocess.DEVNULL,
@@ -46,7 +46,7 @@ def get_paths_with_git_diffs() -> set[Path]:
     return set(
         map(
             lambda path: Path(os.path.realpath(os.path.join(git_root, Path(path)))),
-            changed + new,
+            [p for p in changed + new if p != ""],
         )
     )
 

--- a/mentat/parsers/file_edit.py
+++ b/mentat/parsers/file_edit.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import json
 import os
 from pathlib import Path
+from typing import Any
 
 import attr
 
@@ -36,24 +37,6 @@ class Replacement:
         return self.ending_line < other.ending_line or (
             self.ending_line == other.ending_line
             and self.starting_line < other.ending_line
-        )
-
-    def to_json(self) -> str:
-        return json.dumps(
-            {
-                "starting_line": self.starting_line,
-                "ending_line": self.ending_line,
-                "new_lines": self.new_lines,
-            }
-        )
-
-    @classmethod
-    def from_json(cls, json_str: str) -> "Replacement":
-        data = json.loads(json_str)
-        return cls(
-            starting_line=data["starting_line"],
-            ending_line=data["ending_line"],
-            new_lines=data["new_lines"],
         )
 
 
@@ -129,26 +112,22 @@ class FileEdit:
             self.rename_file_path = None
         return True
 
-    def to_json(self) -> str:
-        replacements_json = [r.to_json() for r in self.replacements]
-        return json.dumps(
-            {
-                "file_path": str(self.file_path),
-                "replacements": replacements_json,
-                "is_creation": self.is_creation,
-                "is_deletion": self.is_deletion,
-                "rename_file_path": (
-                    str(self.rename_file_path) if self.rename_file_path else None
-                ),
-            }
-        )
+    def asdict(self) -> dict[str, Any]:
+        # Convert Replacements to dicts
+        return {
+            "file_path": str(self.file_path),
+            "replacements": [attr.asdict(r) for r in self.replacements],
+            "is_creation": self.is_creation,
+            "is_deletion": self.is_deletion,
+            "rename_file_path": (
+                str(self.rename_file_path) if self.rename_file_path else None
+            ),
+        }
 
     @classmethod
     def from_json(cls, json_str: str) -> "FileEdit":
         data = json.loads(json_str)
-        replacements = [
-            Replacement.from_json(r_json) for r_json in data["replacements"]
-        ]
+        replacements = [Replacement(**r) for r in data["replacements"]]
         return cls(
             file_path=Path(data["file_path"]),
             replacements=replacements,

--- a/mentat/parsers/git_parser.py
+++ b/mentat/parsers/git_parser.py
@@ -37,10 +37,16 @@ class GitParser:
         split_on_diff = git_diff.split("\ndiff --git ")
 
         # Use commit message for conversation
-        commit_message = dedent(split_on_diff[0].split("\n\n")[1].strip())
+        commit_message = ""
+        start_from = 0
+        try:
+            commit_message = dedent(split_on_diff[0].split("\n\n")[1].strip())
+            start_from = 1
+        except IndexError:  # Handle diffs generated file-by-file
+            split_on_diff[0] = split_on_diff[0].replace("diff --git ", "")
 
         file_edits: List[FileEdit] = []
-        for diff in split_on_diff[1:]:
+        for diff in split_on_diff[start_from:]:
             is_creation = "new file mode" in diff
             is_deletion = "deleted file mode" in diff
             first_line = diff.split("\n")[0]

--- a/mentat/sample.py
+++ b/mentat/sample.py
@@ -1,0 +1,115 @@
+from __future__ import annotations
+
+import json
+
+import attr
+from openai.types.chat import ChatCompletionMessageParam
+
+from mentat.code_feature import get_consolidated_feature_refs
+from mentat.git_handler import get_diff_for_file, get_paths_with_git_diffs
+from mentat.parsers.git_parser import GitParser
+from mentat.session_context import SessionContext
+from mentat.session_input import collect_user_input
+
+
+def parse_message(message: ChatCompletionMessageParam) -> str:
+    content = message.get("content")
+    if isinstance(content, str):
+        return content
+    elif isinstance(content, list) and len(content) > 0:
+        content = content[0]
+        if "text" in content and isinstance(content.get("text"), str): # type: ignore
+            return content.get("text") # type: ignore
+        else:
+            return ""
+    else:
+        return ""
+
+
+@attr.define
+class Sample:
+    repo: str = attr.field(default="")
+    merge_base: str = attr.field(default="")
+    diff: str = attr.field(default="")
+    args: list[str] = attr.field(default=[])  # type: ignore
+    messages: list[dict[str, str]] = attr.field(default=[])  # type: ignore
+    edits: list[dict] = attr.field(default=[])  # type: ignore
+
+    @classmethod
+    async def from_context(cls, session_context: SessionContext) -> Sample:
+        # Check for repo and merge_base in config
+        stream = session_context.stream
+        code_context = session_context.code_context
+        config = session_context.config
+        code_file_manager = session_context.code_file_manager
+        conversation = session_context.conversation
+
+        if not config.sample_repo:
+            stream.send("Input sample repo: (e.g. 'https://github.com/your/repo')")
+            config.sample_repo = (await collect_user_input()).data.strip()
+        if not config.sample_merge_base:
+            stream.send("Input sample merge base: (e.g. 'main')")
+            config.sample_merge_base = (await collect_user_input()).data.strip()
+
+        args = list[str]()
+        if code_context.include_files:
+            args += get_consolidated_feature_refs(
+                [f for fs in code_context.include_files.values() for f in fs]
+            )
+
+        messages = list[dict[str, str]]()
+        for m in conversation.get_messages():
+            parsed = parse_message(m)
+            if parsed and m["role"] in {"user", "assistant"}:
+                messages.append({"role": m["role"], "content": parsed})
+
+        # Use "undo" to separate edits and pre-edit diff to merge_base
+        errors = code_file_manager.history.undo()
+        assert not errors, f"Errors while undoing: {errors}"
+        file_edits = code_file_manager.history.undone_edits[-1].copy()
+        edits = [edit.asdict() for edit in file_edits]
+
+        # Diff of commit to pre-edited code
+        changed_files = get_paths_with_git_diffs(config.sample_merge_base)
+        diff_lines: list[str] = []
+        for file in changed_files:
+            git_diff = get_diff_for_file(config.sample_merge_base, file)
+            if git_diff:
+                diff_lines += git_diff.split("\n")
+            else:
+                # Generate diff-like output for new files
+                diff_lines += [
+                    f"diff --git a/{file} b/{file}",
+                    "new file mode 100644",
+                    "--- /dev/null",
+                    f"+++ b/{file}",
+                    "@@ -0,0 +1 @@",
+                ] + [f"+{line}" for line in file.read_text().split("\n")]
+        if diff_lines:
+            parsed_llm_response = GitParser().parse_string("\n".join(diff_lines))
+            diff = "\n".join(parsed_llm_response.full_response)
+        else:
+            diff = ""
+
+        await code_file_manager.history.redo()
+
+        return cls(
+            repo=config.sample_repo,
+            merge_base=config.sample_merge_base,
+            diff=diff,
+            args=args,
+            messages=messages,
+            edits=edits,
+        )
+
+    def to_json(self) -> str:
+        return json.dumps(attr.asdict(self), indent=4)
+
+    def save(self, fname: str) -> None:
+        with open(fname, "w") as f:
+            f.write(self.to_json())
+
+    @classmethod
+    def load(cls, fname: str) -> Sample:
+        with open(fname, "r") as f:
+            return cls(**json.loads(f.read()))

--- a/mentat/sample.py
+++ b/mentat/sample.py
@@ -29,7 +29,6 @@ def parse_message(message: ChatCompletionMessageParam) -> str:
 @attr.define
 class Sample:
     repo: str = attr.field(default="")
-    merge_base: str = attr.field(default="")
     diff: str = attr.field(default="")
     args: list[str] = attr.field(default=[])  # type: ignore
     messages: list[dict[str, str]] = attr.field(default=[])  # type: ignore
@@ -95,7 +94,6 @@ class Sample:
 
         return cls(
             repo=config.sample_repo,
-            merge_base=config.sample_merge_base,
             diff=diff,
             args=args,
             messages=messages,

--- a/tests/commands_test.py
+++ b/tests/commands_test.py
@@ -47,15 +47,13 @@ async def test_commit_command(temp_testbed, mock_collect_user_input):
 
 
 @pytest.mark.asyncio
-async def test_sample_command(
-    temp_testbed, mock_collect_user_input, mock_call_llm_api
-):
+async def test_sample_command(temp_testbed, mock_collect_user_input, mock_call_llm_api):
     mock_collect_user_input.set_stream_messages(
         [
             "Make the edits.",
             "y",
             "/sample",
-            "",
+            "https://github.com/AbanteAI/mentat",
             "HEAD",
             "q",
         ]
@@ -91,16 +89,15 @@ async def test_sample_command(
 
     file_path = str(temp_testbed / "multifile_calculator" / "calculator.py")
     assert sample.get("repo") == "https://github.com/AbanteAI/mentat"
-    assert sample.get("commit") == "HEAD"
-    assert sample.get("config") == [file_path]
-    assert len(sample.get("convo")) == 2
-    assert sample.get("convo")[0].get("content")[0].get("text") == "Make the edits."
+    assert sample.get("merge_base") == "HEAD"
+    assert sample.get("args") == [file_path]
+    assert len(sample.get("messages")) == 2
+    message_0 = sample.get("messages")[0].get("content") == "Make the edits."
     assert len(sample.get("edits")) == 1
-    sample["edits"] = [FileEdit.from_json(e) for e in sample["edits"]]
-    assert sample.get("edits")[0].file_path == Path(file_path)
+    sample["edits"] = [FileEdit(**e) for e in sample["edits"]]
+    assert sample.get("edits")[0].file_path == file_path
     assert len(sample.get("edits")[0].replacements) == 1
-    assert sample.get("context") == [file_path]
-    assert sample.get("diff") == []
+    assert sample.get("diff") == ""
 
 
 @pytest.mark.asyncio

--- a/tests/commands_test.py
+++ b/tests/commands_test.py
@@ -89,7 +89,6 @@ async def test_sample_command(temp_testbed, mock_collect_user_input, mock_call_l
 
     file_path = str(temp_testbed / "multifile_calculator" / "calculator.py")
     assert sample.get("repo") == "https://github.com/AbanteAI/mentat"
-    assert sample.get("merge_base") == "HEAD"
     assert sample.get("args") == [file_path]
     assert len(sample.get("messages")) == 2
     message_0 = sample.get("messages")[0].get("content") == "Make the edits."

--- a/tests/commands_test.py
+++ b/tests/commands_test.py
@@ -47,14 +47,14 @@ async def test_commit_command(temp_testbed, mock_collect_user_input):
 
 
 @pytest.mark.asyncio
-async def test_example_command(
+async def test_sample_command(
     temp_testbed, mock_collect_user_input, mock_call_llm_api
 ):
     mock_collect_user_input.set_stream_messages(
         [
             "Make the edits.",
             "y",
-            "/example",
+            "/sample",
             "",
             "HEAD",
             "q",
@@ -82,25 +82,25 @@ async def test_example_command(
     assert SESSION_CONTEXT.get().conversation.get_messages()[-1]["content"]
 
     try:
-        fn = next(f for f in Path.cwd().glob("*.json") if f.name.startswith("example_"))
+        fn = next(f for f in Path.cwd().glob("*.json") if f.name.startswith("sample_"))
         # Read in the json file
         with open(fn) as f:
-            example = json.load(f)
+            sample = json.load(f)
     except StopIteration:
-        example = False
+        sample = False
 
     file_path = str(temp_testbed / "multifile_calculator" / "calculator.py")
-    assert example.get("repo") == "https://github.com/AbanteAI/mentat"
-    assert example.get("commit") == "HEAD"
-    assert example.get("config") == [file_path]
-    assert len(example.get("convo")) == 2
-    assert example.get("convo")[0].get("content")[0].get("text") == "Make the edits."
-    assert len(example.get("edits")) == 1
-    example["edits"] = [FileEdit.from_json(e) for e in example["edits"]]
-    assert example.get("edits")[0].file_path == Path(file_path)
-    assert len(example.get("edits")[0].replacements) == 1
-    assert example.get("context") == [file_path]
-    assert example.get("diff") == []
+    assert sample.get("repo") == "https://github.com/AbanteAI/mentat"
+    assert sample.get("commit") == "HEAD"
+    assert sample.get("config") == [file_path]
+    assert len(sample.get("convo")) == 2
+    assert sample.get("convo")[0].get("content")[0].get("text") == "Make the edits."
+    assert len(sample.get("edits")) == 1
+    sample["edits"] = [FileEdit.from_json(e) for e in sample["edits"]]
+    assert sample.get("edits")[0].file_path == Path(file_path)
+    assert len(sample.get("edits")[0].replacements) == 1
+    assert sample.get("context") == [file_path]
+    assert sample.get("diff") == []
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
This is a simple tool to aid in the generation of benchmarks / fine-tune samples. The target workflow is:
- Use Mentat to do a task
- Make corrections to its changes directly in the code
- Call the `/sample` command to generate `example_<datetime>.json`, which includes
  - repo
  - diff (changes between upstream/main and starting code)
  - args (e.g. include files, auto-context..)
  - messages (all user & assistance messages before edit)
  - edits (mentat-formatted edits, the target)

With these 5 fields, we'll be able to 
- create benchmarks (with gpt scorer)
- score auto-context (run without any args, compare selected features to include_files)
- create time-tune examples (of mentat-formatted output, or context selection, etc)

This is a draft for now, happy for feedback on the approach. 