### PR TITLE
fix removed lines bug

### DIFF
--- a/mentat/parsers/parser.py
+++ b/mentat/parsers/parser.py
@@ -327,11 +327,13 @@ class Parser(ABC):
         rename_map: dict[Path, Path],
         rel_path: Path,
     ) -> list[str]:
+        ctx = SESSION_CONTEXT.get()
+
         path = rename_map.get(
             rel_path,
             rel_path,
         )
-        return code_file_manager.file_lines.get(path, [])
+        return code_file_manager.file_lines.get(ctx.cwd / path, [])
 
     # These methods aren't abstract, since most parsers will use this implementation, but can be overriden easily
     def provide_line_numbers(self) -> bool:


### PR DESCRIPTION
In #274 we changed file_lines to abs path, but spot was missed, meaning context lines and removed lines couldn't be printed.