### PR TITLE
Move repos to project root

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ benchmark_results
 build
 .mentat_config.json
 tests/benchmarks/repos
+benchmark_repos

--- a/scripts/git_log_to_transcripts.py
+++ b/scripts/git_log_to_transcripts.py
@@ -211,7 +211,7 @@ if __name__ == "__main__":
     args = parser.parse_args()
     repo_name = args.repo.split("/")[-1]
     clone_repo(args.repo, repo_name, depth=args.count)
-    os.chdir(f"tests/benchmarks/repos/{repo_name}")
+    os.chdir(f"benchmark_repos/{repo_name}")
     old_benchmarks = {}
     if os.path.exists("benchmarks.json"):
         with open("benchmarks.json", "r") as f:

--- a/scripts/select_git_transcripts.py
+++ b/scripts/select_git_transcripts.py
@@ -50,7 +50,7 @@ if __name__ == "__main__":
     parser.add_argument(
         "--file",
         type=str,
-        default="tests/benchmarks/repos/mentat/commit_information.json",
+        default="repos/mentat/commit_information.json",
         help="The commit information file to convert to transcripts",
     )
     parser.add_argument(

--- a/tests/benchmarks/benchmarks/mentat/license_update.py
+++ b/tests/benchmarks/benchmarks/mentat/license_update.py
@@ -24,7 +24,7 @@ minimum_context = ["tests/license_check.py:11-22"]
 
 def verify():
     try:
-        import tests.benchmarks.repos.mentat.tests.license_check as license_check
+        import benchmark_repos.mentat.tests.license_check as license_check
 
         importlib.reload(license_check)
         return set(license_check.accepted_licenses) == set(

--- a/tests/benchmarks/context_benchmark.py
+++ b/tests/benchmarks/context_benchmark.py
@@ -27,9 +27,9 @@ class MockStream:
 
 
 def _load_benchmarks() -> dict[str, dict[str, Any]]:
-    """Load all benchmarks found in tests/benchmarks/repos"""
+    """Load all benchmarks found in benchmark_repos"""
     benchmarks = {}
-    benchmarks_dir = Path(__file__).parent / "repos"
+    benchmarks_dir = Path(__file__).parent / "../../benchmark_repos"
     for repo_dir in benchmarks_dir.iterdir():
         benchmarks_path = repo_dir / "benchmarks.json"
         if benchmarks_path.exists():

--- a/tests/benchmarks/edit_rubric_benchmark.py
+++ b/tests/benchmarks/edit_rubric_benchmark.py
@@ -82,7 +82,7 @@ def evaluate_diff(diff: str) -> dict[str, int]:
 async def test_edit_quality(
     benchmarks, max_benchmarks, evaluate_baseline, repo, refresh_repo
 ):
-    repo_path = Path(__file__).parent / f"repos/{repo}"
+    repo_path = Path(__file__).parent / f"../../benchmark_repos/{repo}"
     tests = load_tests(repo_path)
     results = load_results(repo_path)
 

--- a/tests/benchmarks/exercism_practice.py
+++ b/tests/benchmarks/exercism_practice.py
@@ -85,7 +85,7 @@ async def failure_analysis(exercise_runner, language):
     response = ""
     try:
         llm_api_handler = SESSION_CONTEXT.get().llm_api_handler
-        async for chunk in await llm_api_handler.call_llm_api(messages, model):
+        async for chunk in await llm_api_handler.call_llm_api(messages, model, True):
             content = chunk["choices"][0]["delta"].get("content", "")
             response += content
     except BadRequestError:

--- a/tests/benchmarks/utils.py
+++ b/tests/benchmarks/utils.py
@@ -3,7 +3,7 @@ from pathlib import Path
 
 from git import Repo
 
-CLONE_TO_DIR = Path(__file__).parent / "repos"
+CLONE_TO_DIR = Path(__file__).parent / "../../benchmark_repos"
 
 
 def clone_repo(


### PR DESCRIPTION
Instead of being in `tests/benchmarks/repos` repos cloned for benchmarking purposes are put under `benchmark_repos`.