### PR TITLE
Github action to run and upload benchmarks

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -5,6 +5,7 @@ name: Benchmark
 on:
   schedule:
     - cron: '0 0 * * *'  # Runs at midnight UTC every day
+  workflow_dispatch:
 
 jobs:
   run-benchmarks:

--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -1,0 +1,28 @@
+# This workflow runs our benchmarks uploads the results to S3 and sends a notification to
+# slack when it's done.
+name: Benchmark
+
+on:
+  schedule:
+    - cron: '0 0 * * *'  # Runs at midnight UTC every day
+
+jobs:
+  run-benchmarks:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+
+      - name: Install dependencies
+        run: |
+          python -m pip install .
+          pip install -r dev-requirements.txt
+
+      - name: Run and upload benchmarks
+        run: ./scripts/run_and_upload_benchmarks.sh
+        env:
+            AWS_ACCESS_KEY_ID: ${{ secrets.AWS_S3_ACCESS_KEY_ID }}
+            AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_S3_SECRET_ACCESS_KEY }}
+            AWS_DEFAULT_REGION: 'us-east-2'
+            SLACK_BENCHMARK_NOTIFICATION_WEBHOOK: ${{ secrets.SLACK_BENCHMARK_NOTIFICATION_WEBHOOK }}

--- a/scripts/run_and_upload_benchmarks.sh
+++ b/scripts/run_and_upload_benchmarks.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+
+pytest -s tests/benchmarks/exercism_practice.py \
+    --max_iterations 2 \
+    --max_workers 1 \
+    --max_benchmarks 4 \ # Starting low
+    --language javascript \
+    --benchmark
+
+# Upload results to S3
+TIMESTAMP=$(date +%Y%m%d%H%M%S)
+aws s3 cp benchmark_repos/exercism-javascript/results.html s3://abante-benchmark-results/exercism-javascript-results-${TIMESTAMP}.html
+
+# Send slack notification
+RESULTS_URL="https://abante-benchmark-results.s3.amazonaws.com/exercism-javascript-results-${TIMESTAMP}.html"
+curl -X POST -H "Content-Type: application/json" -d "{\"text\": \"Benchmark results: ${RESULTS_URL}\"}" $SLACK_BENCHMARK_NOTIFICATION_WEBHOOK
+
+


### PR DESCRIPTION
A daily github action that:
- Runs one small benchmark (we should expand after we've validated this)
- Uploads the results.html to a public s3 bucket.
    - Secrets to upload to the bucket are already added.
    - I think it's fine if the benchmarks are public since all the code to run them is public anyway. If we clean them up a bit and make a central dashboard I could even see hosting the bucket as a static site at benchmarks.abante.ai
- Makes a slack message in the benchmarking channel.
    - The webhook url is an already added secret. It's not that important to keep this secret but in theory people could spam us with it.