### PR TITLE
Add helper func to split interval string from path

### DIFF
--- a/mentat/code_context.py
+++ b/mentat/code_context.py
@@ -29,6 +29,7 @@ from mentat.include_files import (
     print_path_tree,
     validate_and_format_path,
 )
+from mentat.interval import split_intervals_from_path
 from mentat.llm_api_handler import count_tokens, is_test_environment
 from mentat.session_context import SESSION_CONTEXT
 from mentat.session_stream import SessionStream
@@ -391,8 +392,7 @@ class CodeContext:
 
         excluded_paths: Set[Path] = set()
 
-        interval_path, interval_str = str(path).rsplit(":", 1)
-        interval_path = Path(interval_path)
+        interval_path, interval_str = split_intervals_from_path(path)
         if interval_path not in self.include_files:
             session_context.stream.send(
                 f"Path {interval_path} not in context", color="light_red"

--- a/mentat/code_feature.py
+++ b/mentat/code_feature.py
@@ -12,7 +12,7 @@ from mentat.ctags import get_ctag_lines_and_names
 from mentat.diff_context import annotate_file_message, parse_diff
 from mentat.errors import MentatError
 from mentat.git_handler import get_diff_for_file
-from mentat.interval import Interval, parse_intervals
+from mentat.interval import Interval, parse_intervals, split_intervals_from_path
 from mentat.llm_api_handler import count_tokens
 from mentat.session_context import SESSION_CONTEXT
 from mentat.utils import get_relative_path, sha256
@@ -123,14 +123,12 @@ class CodeFeature:
             self.path = Path(path)
             self.interval = Interval(0, math.inf)
         else:
-            path = str(path)
-            split = path.rsplit(":", 1)
-            self.path = Path(split[0])
+            self.path, interval = split_intervals_from_path(path)
             if not self.path.exists():
                 self.path = Path(path)
                 self.interval = Interval(0, math.inf)
             else:
-                interval = parse_intervals(split[1])
+                interval = parse_intervals(interval)
                 if len(interval) > 1:
                     raise MentatError("CodeFeatures should only have on interval.")
                 self.interval = interval[0]

--- a/mentat/include_files.py
+++ b/mentat/include_files.py
@@ -9,7 +9,7 @@ from typing import Any, List, Set
 from mentat.code_feature import CodeFeature
 from mentat.errors import PathValidationError
 from mentat.git_handler import get_git_root_for_path, get_non_gitignored_files
-from mentat.interval import parse_intervals
+from mentat.interval import parse_intervals, split_intervals_from_path
 from mentat.session_context import SESSION_CONTEXT
 
 
@@ -33,10 +33,9 @@ class PathType(Enum):
 
 
 def is_interval_path(path: Path) -> bool:
-    splits = str(path).rsplit(":", 1)
-    if len(splits) != 2:
+    path, interval_str = split_intervals_from_path(path)
+    if not interval_str:
         return False
-    interval_str = splits[1]
     intervals = parse_intervals(interval_str)
     if len(intervals) == 0:
         return False
@@ -77,8 +76,7 @@ def validate_file_path(path: Path, check_for_text: bool = True) -> None:
 
 
 def validate_file_interval_path(path: Path, check_for_text: bool = True) -> None:
-    _interval_path, interval_str = str(path).rsplit(":", 1)
-    interval_path = Path(_interval_path)
+    interval_path, interval_str = split_intervals_from_path(path)
     if not interval_path.is_absolute():
         raise PathValidationError(f"File interval {path} is not absolute")
     if not interval_path.exists():
@@ -264,7 +262,7 @@ def get_code_features_for_path(
         case PathType.FILE:
             code_features = set([CodeFeature(validated_path)])
         case PathType.FILE_INTERVAL:
-            interval_path, interval_str = str(validated_path).rsplit(":", 1)
+            interval_path, interval_str = split_intervals_from_path(validated_path)
             intervals = parse_intervals(interval_str)
             code_features: Set[CodeFeature] = set()
             for interval in intervals:

--- a/mentat/interval.py
+++ b/mentat/interval.py
@@ -1,6 +1,21 @@
 from __future__ import annotations
 
+import re
+from pathlib import Path
+
 import attr
+
+
+def split_intervals_from_path(custom_path: str | Path) -> tuple[Path, str]:
+    match = re.match(
+        r"(.*?):((\d+-\d+|\d+)(,\d+(-\d+)?)*$)",  # One or more intervals/numbers
+        str(custom_path),
+    )
+    if match:
+        path, intervals = match.groups()[0], match.groups()[1]
+        return Path(path), intervals
+    else:
+        return Path(custom_path), ""
 
 
 def parse_intervals(interval_string: str) -> list[Interval]:


### PR DESCRIPTION
It's been pointed out that the way we check for intervals `path_str.rsplit(":")` won't work on a Windows absolute path. This fixes that by doing it with `re` in a helper func.