### PR TITLE
Benchmark Runner results shown in viewer

### DIFF
--- a/mentat/resources/templates/benchmark.jinja
+++ b/mentat/resources/templates/benchmark.jinja
@@ -69,7 +69,7 @@
                                 {% elif section.type == "code" %}
                                     <pre><code>{{ section.content }}</code></pre>
                                 {% elif section.type == "json" %}
-                                    <pre><code>{{ section.content |tojson(indent=4)|safe}}</code></pre>
+                                    <pre>{{ section.content |tojson(indent=4)|safe}}</pre>
                                 {% elif section.type == "transcript" %}
                                     {{ transcript_container(section.content) }}
                                 {% endif %}

--- a/mentat/resources/templates/benchmark.jinja
+++ b/mentat/resources/templates/benchmark.jinja
@@ -28,6 +28,14 @@
             });
         </script>
         <script>
+            function toggleVisibility(family) {
+                const familyButtons = document.querySelectorAll('.' + family + '-child');
+                familyButtons.forEach(button => {
+                    button.classList.toggle('hidden');
+                });
+            }
+        </script>
+        <script>
             {% include 'js/transcript.js' %}
         </script>
     </head>
@@ -39,8 +47,15 @@
         </div>
         <div id="container">
             <div id="selector">
-                {% for test, result in summary.results_map.items() %}
-                    <button class="{{ result.display_color() }}" onclick="window.location.hash='{{ result.escaped_name() }}'">{{ test }}</button>
+                {% for family, results in summary.result_groups.items() %}
+                    {% if results|length == 1 %}
+                        <button class="{{ results[0].display_color() }}" onclick="window.location.hash='{{ results[0].name }}'">{{ results[0].name }}</button>
+                    {% else %}
+                        <button class="{{ results[0].display_color() }}" onclick="toggleVisibility('{{family}}')">{{family}}</button>
+                        {% for result in results %}
+                            <button class="hidden {{ family }}-child family-child {{ result.display_color() }}" onclick="window.location.hash='{{ result.name }}'">{{ result.name }}</button>
+                        {% endfor %}
+                    {% endif %}
                 {% endfor %}
             </div>
             <div id="viewer">

--- a/mentat/resources/templates/benchmark.jinja
+++ b/mentat/resources/templates/benchmark.jinja
@@ -2,7 +2,7 @@
 <!DOCTYPE html>
 <html>
     <head>
-        <title>Exercism Benchmark Results</title>
+        <title>Benchmark Results</title>
         <style>
             {% include 'css/benchmark.css' %}
             {% include 'css/transcript.css' %}
@@ -40,7 +40,7 @@
         <div id="container">
             <div id="selector">
                 {% for test, result in summary.results_map.items() %}
-                    <button class="{{ 'success' if result.passed else 'failure' }}" onclick="window.location.hash='{{ result.escaped_name }}'">{{ test }}</button>
+                    <button class="{{ result.display_color() }}" onclick="window.location.hash='{{ result.escaped_name() }}'">{{ test }}</button>
                 {% endfor %}
             </div>
             <div id="viewer">
@@ -52,9 +52,9 @@
                                 {% if section.type == "text" %}
                                     {{ section.content }}
                                 {% elif section.type == "code" %}
-                                    <pre><code>
-                                        {{ section.content }}
-                                    </code></pre>
+                                    <pre><code>{{ section.content }}</code></pre>
+                                {% elif section.type == "json" %}
+                                    <pre><code>{{ section.content |tojson(indent=4)|safe}}</code></pre>
                                 {% elif section.type == "transcript" %}
                                     {{ transcript_container(section.content) }}
                                 {% endif %}

--- a/mentat/resources/templates/css/benchmark.css
+++ b/mentat/resources/templates/css/benchmark.css
@@ -84,6 +84,10 @@ button.red {
     border-color: #f5c6cb;
 }
 
+.hidden {
+    display: none;
+}
+
 .content {
     white-space: pre-wrap;
     word-break: break-word;
@@ -93,6 +97,10 @@ button.red {
     margin-bottom: 10px;
     overflow-y: scroll;
     max-height: 70vh;
+}
+
+.family-child {
+    margin-left: 20px;
 }
 
 .content .container {

--- a/mentat/resources/templates/css/benchmark.css
+++ b/mentat/resources/templates/css/benchmark.css
@@ -60,13 +60,25 @@ button:hover {
     background-color: #e9e9e9;
 }
 
-button.success {
+button.green {
     background-color: #d4edda;
     color: #155724;
     border-color: #c3e6cb;
 }
 
-button.failure {
+button.yellow {
+    background-color: #fff3cd;
+    color: #856404;
+    border-color: #ffeeba;
+}
+
+button.grey {
+    background-color: #f8f9fa;
+    color: #6c757d;
+    border-color: #f8f9fa;
+}
+
+button.red {
     background-color: #f8d7da;
     color: #721c24;
     border-color: #f5c6cb;

--- a/mentat/resources/templates/exercism_benchmark.jinja
+++ b/mentat/resources/templates/exercism_benchmark.jinja
@@ -44,23 +44,22 @@
                 {% endfor %}
             </div>
             <div id="viewer">
-                {% for test, result in summary.results_map.items() %}
+                {% for test, formatted_result in summary.formatted_results().items() %}
                     <div id="{{ test }}" class="result-section">
-                        <h1>Instructions:</h1>
-                        <div class="content">{{ result.instructions }}</div>
-                        <h1>Code:</h1>
-                        <div class="content">
-                            <pre><code>
-                                {{ result.code }}
-                            </code></pre>
-                        </div>
-                        <h1>Analysis:</h1>
-                        <div class="content">{{ result.response }}</div>
-                        <h1>Test Output:</h1>
-                        <div class="content">{{ result.test_output }}</div>
-
-                        <h1>Transcript</h1>
-                        <div class="content">{{ transcript_container(result.transcript) }}</div>
+                        {% for display_name, section in formatted_result.items() %}
+                        <h1>{{ display_name|capitalize }}</h1>
+                            <div class="content">
+                                {% if section.type == "text" %}
+                                    {{ section.content }}
+                                {% elif section.type == "code" %}
+                                    <pre><code>
+                                        {{ section.content }}
+                                    </code></pre>
+                                {% elif section.type == "transcript" %}
+                                    {{ transcript_container(section.content) }}
+                                {% endif %}
+                            </div>
+                        {% endfor %}
                     </div>
                 {% endfor %}
             </div>

--- a/mentat/resources/templates/exercism_benchmark.jinja
+++ b/mentat/resources/templates/exercism_benchmark.jinja
@@ -40,7 +40,7 @@
         <div id="container">
             <div id="selector">
                 {% for test, result in summary.results_map.items() %}
-                    <button class="{{ 'success' if result.passed else 'failure' }}" onclick="window.location.hash='{{ test }}'">{{ test }}</button>
+                    <button class="{{ 'success' if result.passed else 'failure' }}" onclick="window.location.hash='{{ result.escaped_name }}'">{{ test }}</button>
                 {% endfor %}
             </div>
             <div id="viewer">

--- a/mentat/resources/templates/exercism_benchmark.jinja
+++ b/mentat/resources/templates/exercism_benchmark.jinja
@@ -33,11 +33,9 @@
     </head>
     <body>
         <div id="header">
-            <p>Average tokens per iteration for passed tests: {{ summary.avgTokens }}</p>
-            <p>Total cost: {{ summary.cost }}</p>
-            <p>Passed: {{ summary.passed }}</p>
-            <p>Failed: {{ summary.failed }}</p>
-            <p>Reasons: {% for reason, count in summary.reasons.items() %}{{ reason }}: {{ count }} {% endfor %}</p>
+            {% for field, data in summary.formatted_summary().items() %}
+                <p>{{ field|capitalize }}: {{ data }}</p>
+            {% endfor %}
         </div>
         <div id="container">
             <div id="selector">
@@ -60,7 +58,6 @@
                         <div class="content">{{ result.response }}</div>
                         <h1>Test Output:</h1>
                         <div class="content">{{ result.test_output }}</div>
-
 
                         <h1>Transcript</h1>
                         <div class="content">{{ transcript_container(result.transcript) }}</div>

--- a/tests/benchmarks/benchmark_result.py
+++ b/tests/benchmarks/benchmark_result.py
@@ -1,5 +1,5 @@
 import json
-from typing import Optional
+from typing import Optional, Tuple
 
 import attr
 
@@ -8,18 +8,21 @@ from mentat.transcripts import Transcript
 
 @attr.define
 class BenchmarkResult:
-    iterations: int
-    passed: bool
-    name: str
-    cost: float
-    tokens: int
+    iterations: int = attr.ib(metadata={"aggregation": "histogram"})
+    passed: bool = attr.ib(metadata={"aggregation": "percent"})
+    name: str = attr.ib()
+    cost: float = attr.ib(metadata={"aggregation": "sum"})
+    tokens: int = attr.ib(metadata={"aggregation": "average"})
     transcript: Optional[Transcript] = attr.ib(default=None)
     instructions: Optional[str] = attr.ib(default=None)
     code: Optional[str] = attr.ib(default=None)
-    test_output: Optional[str] = attr.ib(default=None)
-    response: Optional[str] = attr.ib(default=None)
-    reason: Optional[str] = attr.ib(default=None)
-    success: Optional[bool] = attr.ib(default=None)
+    test_output: Optional[str] = attr.ib(
+        default=None, metadata={"formatted_name": "Test output"}
+    )
+    response: Optional[str] = attr.ib(
+        default=None, metadata={"formatted_name": "Analysis"}
+    )
+    reason: Optional[str] = attr.ib(default=None, metadata={"aggregation": "histogram"})
 
     def to_json(self):
         return json.dumps(attr.asdict(self))
@@ -27,3 +30,74 @@ class BenchmarkResult:
     @classmethod
     def from_json(cls, json_str):
         return cls(**json.loads(json_str))
+
+
+class BenchmarkResultSummary:
+    results: list[BenchmarkResult]
+    results_map: dict[str, BenchmarkResult]
+    summary: dict[str, Tuple[int | float | str, float]]
+
+    def __init__(self, results: list[BenchmarkResult]):
+        self.results = results
+        self.results_map = {result.name: result for result in results}
+        self.summary = self.aggregate_results()
+
+    def aggregate_results(self) -> dict[str, Tuple[int | float | str, float]]:
+        summary = {}
+        for field in attr.fields(BenchmarkResult):
+            if "aggregation" in field.metadata:
+                name = field.name
+                values = [
+                    getattr(result, name)
+                    for result in self.results
+                    if getattr(result, name) is not None
+                ]
+                aggregation_type = field.metadata["aggregation"]
+                if aggregation_type == "sum":
+                    summary[name] = (sum(values), len(values))
+                elif aggregation_type == "average":
+                    summary[name] = (
+                        (sum(values) / len(values), len(values)) if values else (0, 0)
+                    )
+                elif aggregation_type == "percent":
+                    summary[name] = (
+                        (sum(values) / len(values) * 100, len(values))
+                        if values
+                        else (0, 0)
+                    )
+                elif aggregation_type == "histogram":
+                    histogram = {val: values.count(val) for val in set(values)}
+                    summary[name] = (histogram, len(values))
+                elif aggregation_type == "none":
+                    summary[name] = (values, len(values))
+        return summary
+
+    def formatted_summary(self) -> dict[str, str]:
+        formatted = {}
+        for field in attr.fields(BenchmarkResult):
+            if "aggregation" in field.metadata:
+                name = field.name
+                value, count = self.summary[name]
+                formatted_value = ""
+                aggregation_type = field.metadata["aggregation"]
+                if aggregation_type == "average":
+                    formatted_name = f"{name} (avg)"
+                else:
+                    formatted_name = name
+
+                if isinstance(value, float):
+                    formatted_value = f"{value:.2f}"
+                elif isinstance(value, dict):
+                    formatted_value = ", ".join(f"{k}: {v}" for k, v in value.items())
+                else:
+                    formatted_value = str(value)
+
+                # Add units based on aggregation type
+                if aggregation_type == "sum" and "cost" in formatted_name:
+                    formatted[formatted_name] = f"${formatted_value}"
+                elif aggregation_type == "percent":
+                    formatted[formatted_name] = f"{formatted_value}%"
+                else:
+                    formatted[formatted_name] = formatted_value
+
+        return formatted

--- a/tests/benchmarks/benchmark_result.py
+++ b/tests/benchmarks/benchmark_result.py
@@ -1,4 +1,5 @@
 import json
+import re
 from typing import Optional
 
 import attr
@@ -8,11 +9,13 @@ from mentat.transcripts import Transcript
 
 @attr.define
 class BenchmarkResult:
-    iterations: int = attr.ib(metadata={"aggregation": "histogram"})
     passed: bool = attr.ib(metadata={"aggregation": "percent"})
     name: str = attr.ib()
     cost: float = attr.ib(metadata={"aggregation": "sum"})
     tokens: int = attr.ib(metadata={"aggregation": "average"})
+    iterations: Optional[int] = attr.ib(
+        default=None, metadata={"aggregation": "histogram"}
+    )
     transcript: Optional[Transcript] = attr.ib(
         default=None, metadata={"display": "transcript"}
     )
@@ -25,6 +28,18 @@ class BenchmarkResult:
         default=None, metadata={"formatted_name": "Analysis", "display": "text"}
     )
     reason: Optional[str] = attr.ib(default=None, metadata={"aggregation": "histogram"})
+    # New optional fields for benchmark results
+    diff_grade: Optional[dict] = attr.ib(default=None, metadata={"display": "json"})
+    response_grade: Optional[dict] = attr.ib(default=None, metadata={"display": "json"})
+    comparison_grade: Optional[dict] = attr.ib(
+        default=None, metadata={"display": "json"}
+    )
+    verify: Optional[bool] = attr.ib(default=None, metadata={"aggregation": "percent"})
+
+    @property
+    def escaped_name(self) -> str:
+        """For use as html id"""
+        return re.sub(r"[ '\"/\\-^]", "", self.name).replace(" ", "_")
 
     def to_json(self):
         return json.dumps(attr.asdict(self))

--- a/tests/benchmarks/benchmark_result.py
+++ b/tests/benchmarks/benchmark_result.py
@@ -33,7 +33,7 @@ class BenchmarkResult:
     diff_grade: Optional[dict] = attr.ib(default=None, metadata={"display": "json"})
     response_grade: Optional[dict] = attr.ib(default=None, metadata={"display": "json"})
     comparison_grade: Optional[dict] = attr.ib(
-        default=None, metadata={"display": "code"}
+        default=None, metadata={"display": "json"}
     )
     verify: Optional[bool] = attr.ib(default=None, metadata={"aggregation": "percent"})
     off_by_one: Optional[bool] = attr.ib(

--- a/tests/benchmarks/benchmark_result.py
+++ b/tests/benchmarks/benchmark_result.py
@@ -1,5 +1,5 @@
 import json
-from typing import Optional, Tuple
+from typing import Optional
 
 import attr
 
@@ -13,14 +13,16 @@ class BenchmarkResult:
     name: str = attr.ib()
     cost: float = attr.ib(metadata={"aggregation": "sum"})
     tokens: int = attr.ib(metadata={"aggregation": "average"})
-    transcript: Optional[Transcript] = attr.ib(default=None)
-    instructions: Optional[str] = attr.ib(default=None)
-    code: Optional[str] = attr.ib(default=None)
+    transcript: Optional[Transcript] = attr.ib(
+        default=None, metadata={"display": "transcript"}
+    )
+    instructions: Optional[str] = attr.ib(default=None, metadata={"display": "text"})
+    code: Optional[str] = attr.ib(default=None, metadata={"display": "code"})
     test_output: Optional[str] = attr.ib(
-        default=None, metadata={"formatted_name": "Test output"}
+        default=None, metadata={"formatted_name": "Test output", "display": "code"}
     )
     response: Optional[str] = attr.ib(
-        default=None, metadata={"formatted_name": "Analysis"}
+        default=None, metadata={"formatted_name": "Analysis", "display": "text"}
     )
     reason: Optional[str] = attr.ib(default=None, metadata={"aggregation": "histogram"})
 
@@ -30,74 +32,3 @@ class BenchmarkResult:
     @classmethod
     def from_json(cls, json_str):
         return cls(**json.loads(json_str))
-
-
-class BenchmarkResultSummary:
-    results: list[BenchmarkResult]
-    results_map: dict[str, BenchmarkResult]
-    summary: dict[str, Tuple[int | float | str, float]]
-
-    def __init__(self, results: list[BenchmarkResult]):
-        self.results = results
-        self.results_map = {result.name: result for result in results}
-        self.summary = self.aggregate_results()
-
-    def aggregate_results(self) -> dict[str, Tuple[int | float | str, float]]:
-        summary = {}
-        for field in attr.fields(BenchmarkResult):
-            if "aggregation" in field.metadata:
-                name = field.name
-                values = [
-                    getattr(result, name)
-                    for result in self.results
-                    if getattr(result, name) is not None
-                ]
-                aggregation_type = field.metadata["aggregation"]
-                if aggregation_type == "sum":
-                    summary[name] = (sum(values), len(values))
-                elif aggregation_type == "average":
-                    summary[name] = (
-                        (sum(values) / len(values), len(values)) if values else (0, 0)
-                    )
-                elif aggregation_type == "percent":
-                    summary[name] = (
-                        (sum(values) / len(values) * 100, len(values))
-                        if values
-                        else (0, 0)
-                    )
-                elif aggregation_type == "histogram":
-                    histogram = {val: values.count(val) for val in set(values)}
-                    summary[name] = (histogram, len(values))
-                elif aggregation_type == "none":
-                    summary[name] = (values, len(values))
-        return summary
-
-    def formatted_summary(self) -> dict[str, str]:
-        formatted = {}
-        for field in attr.fields(BenchmarkResult):
-            if "aggregation" in field.metadata:
-                name = field.name
-                value, count = self.summary[name]
-                formatted_value = ""
-                aggregation_type = field.metadata["aggregation"]
-                if aggregation_type == "average":
-                    formatted_name = f"{name} (avg)"
-                else:
-                    formatted_name = name
-
-                if isinstance(value, float):
-                    formatted_value = f"{value:.2f}"
-                elif isinstance(value, dict):
-                    formatted_value = ", ".join(f"{k}: {v}" for k, v in value.items())
-                else:
-                    formatted_value = str(value)
-
-                # Add units based on aggregation type
-                if aggregation_type == "sum" and "cost" in formatted_name:
-                    formatted[formatted_name] = f"${formatted_value}"
-                elif aggregation_type == "percent":
-                    formatted[formatted_name] = f"{formatted_value}%"
-                else:
-                    formatted[formatted_name] = formatted_value
-
-        return formatted

--- a/tests/benchmarks/benchmark_result.py
+++ b/tests/benchmarks/benchmark_result.py
@@ -9,10 +9,9 @@ from mentat.transcripts import Transcript
 
 @attr.define
 class BenchmarkResult:
-    passed: bool = attr.ib(metadata={"aggregation": "percent"})
     name: str = attr.ib()
-    cost: float = attr.ib(metadata={"aggregation": "sum"})
-    tokens: int = attr.ib(metadata={"aggregation": "average"})
+    cost: Optional[float] = attr.ib(default=None, metadata={"aggregation": "sum"})
+    tokens: Optional[int] = attr.ib(default=None, metadata={"aggregation": "average"})
     iterations: Optional[int] = attr.ib(
         default=None, metadata={"aggregation": "histogram"}
     )
@@ -28,18 +27,58 @@ class BenchmarkResult:
         default=None, metadata={"formatted_name": "Analysis", "display": "text"}
     )
     reason: Optional[str] = attr.ib(default=None, metadata={"aggregation": "histogram"})
+    # For exercism benchmarks
+    passed: Optional[bool] = attr.ib(default=None, metadata={"aggregation": "percent"})
     # New optional fields for benchmark results
     diff_grade: Optional[dict] = attr.ib(default=None, metadata={"display": "json"})
     response_grade: Optional[dict] = attr.ib(default=None, metadata={"display": "json"})
     comparison_grade: Optional[dict] = attr.ib(
-        default=None, metadata={"display": "json"}
+        default=None, metadata={"display": "code"}
     )
     verify: Optional[bool] = attr.ib(default=None, metadata={"aggregation": "percent"})
+    off_by_one: Optional[bool] = attr.ib(
+        default=None, metadata={"aggregation": "percent"}
+    )
+    indentation_error: Optional[bool] = attr.ib(
+        default=None, metadata={"aggregation": "percent"}
+    )
+    syntax_error: Optional[bool] = attr.ib(
+        default=None, metadata={"aggregation": "percent"}
+    )
+    missing_functionality: Optional[bool] = attr.ib(
+        default=None, metadata={"aggregation": "percent"}
+    )
+    extra_functionality: Optional[bool] = attr.ib(
+        default=None, metadata={"aggregation": "percent"}
+    )
+    referenced_format: Optional[bool] = attr.ib(
+        default=None, metadata={"aggregation": "percent"}
+    )
 
-    @property
     def escaped_name(self) -> str:
         """For use as html id"""
         return re.sub(r"[ '\"/\\-^]", "", self.name).replace(" ", "_")
+
+    def display_color(self) -> str:
+        if self.passed is None:
+            if self.indentation_error or self.off_by_one or self.syntax_error:
+                return "grey"
+            if (
+                self.missing_functionality
+                or self.extra_functionality
+                or self.referenced_format
+            ):
+                return "yellow"
+            if self.verify is not None:
+                if self.verify:
+                    return "green"
+                else:
+                    return "red"
+            return "green"
+        elif self.passed:
+            return "green"
+        else:
+            return "red"
 
     def to_json(self):
         return json.dumps(attr.asdict(self))

--- a/tests/benchmarks/benchmark_result.py
+++ b/tests/benchmarks/benchmark_result.py
@@ -1,5 +1,4 @@
 import json
-import re
 from typing import Optional
 
 import attr
@@ -10,6 +9,7 @@ from mentat.transcripts import Transcript
 @attr.define
 class BenchmarkResult:
     name: str = attr.ib()
+    family: Optional[str] = attr.ib(default=None)
     cost: Optional[float] = attr.ib(default=None, metadata={"aggregation": "sum"})
     tokens: Optional[int] = attr.ib(default=None, metadata={"aggregation": "average"})
     iterations: Optional[int] = attr.ib(
@@ -54,10 +54,6 @@ class BenchmarkResult:
     referenced_format: Optional[bool] = attr.ib(
         default=None, metadata={"aggregation": "percent"}
     )
-
-    def escaped_name(self) -> str:
-        """For use as html id"""
-        return re.sub(r"[ '\"/\\-^]", "", self.name).replace(" ", "_")
 
     def display_color(self) -> str:
         if self.passed is None:

--- a/tests/benchmarks/benchmark_result_summary.py
+++ b/tests/benchmarks/benchmark_result_summary.py
@@ -1,0 +1,92 @@
+from typing import Tuple
+
+import attr
+
+from tests.benchmarks.benchmark_result import BenchmarkResult
+
+
+class BenchmarkResultSummary:
+    results: list[BenchmarkResult]
+    results_map: dict[str, BenchmarkResult]
+    summary: dict[str, Tuple[int | float | str, float]]
+
+    def __init__(self, results: list[BenchmarkResult]):
+        self.results = results
+        self.results_map = {result.name: result for result in results}
+        self.summary = self.aggregate_results()
+
+    def aggregate_results(self) -> dict[str, Tuple[int | float | str, float]]:
+        summary = {}
+        for field in attr.fields(BenchmarkResult):
+            if "aggregation" in field.metadata:
+                name = field.name
+                values = [
+                    getattr(result, name)
+                    for result in self.results
+                    if getattr(result, name) is not None
+                ]
+                aggregation_type = field.metadata["aggregation"]
+                if aggregation_type == "sum":
+                    summary[name] = (sum(values), len(values))
+                elif aggregation_type == "average":
+                    summary[name] = (
+                        (sum(values) / len(values), len(values)) if values else (0, 0)
+                    )
+                elif aggregation_type == "percent":
+                    summary[name] = (
+                        (sum(values) / len(values) * 100, len(values))
+                        if values
+                        else (0, 0)
+                    )
+                elif aggregation_type == "histogram":
+                    histogram = {val: values.count(val) for val in set(values)}
+                    summary[name] = (histogram, len(values))
+                elif aggregation_type == "none":
+                    summary[name] = (values, len(values))
+        return summary
+
+    def formatted_summary(self) -> dict[str, str]:
+        formatted = {}
+        for field in attr.fields(BenchmarkResult):
+            if "aggregation" in field.metadata:
+                name = field.name
+                value, count = self.summary[name]
+                formatted_value = ""
+                aggregation_type = field.metadata["aggregation"]
+                if aggregation_type == "average":
+                    formatted_name = f"{name} (avg)"
+                else:
+                    formatted_name = name
+
+                if isinstance(value, float):
+                    formatted_value = f"{value:.2f}"
+                elif isinstance(value, dict):
+                    formatted_value = ", ".join(f"{k}: {v}" for k, v in value.items())
+                else:
+                    formatted_value = str(value)
+
+                # Add units based on aggregation type
+                if aggregation_type == "sum" and "cost" in formatted_name:
+                    formatted[formatted_name] = f"${formatted_value}"
+                elif aggregation_type == "percent":
+                    formatted[formatted_name] = f"{formatted_value}%"
+                else:
+                    formatted[formatted_name] = formatted_value
+
+        return formatted
+
+    def formatted_results(self) -> list[dict[str, str]]:
+        formatted = {}
+        for result in self.results:
+            formatted_result = {}
+            for field in attr.fields(BenchmarkResult):
+                if "display" in field.metadata:
+                    name = field.name
+                    value = getattr(result, name)
+                    display_name = field.metadata.get("display_name", name)
+                    formatted_result[display_name] = {
+                        "content": value,
+                        "type": field.metadata["display"],
+                    }
+            formatted[result.name] = formatted_result
+        return formatted

--- a/tests/benchmarks/benchmark_result_summary.py
+++ b/tests/benchmarks/benchmark_result_summary.py
@@ -12,10 +12,21 @@ class BenchmarkResultSummary:
     def __init__(self, results: list[BenchmarkResult]):
         self.results = results
         self.results_map = {result.name: result for result in results}
+        self.result_groups = self.group_results()
         self.summary: dict[str, Tuple[int | float | str, float]] = (
             self.aggregate_results()
         )
-        print(self.aggregate_results())
+
+    def group_results(self) -> dict[str, list[BenchmarkResult]]:
+        groups = {}
+        for result in self.results:
+            if result.family is None:
+                groups[result.name] = [result]
+            else:
+                if result.family not in groups:
+                    groups[result.family] = []
+                groups[result.family].append(result)
+        return groups
 
     def aggregate_results(self) -> dict[str, Tuple[int | float | str, float]]:
         summary = {}
@@ -100,7 +111,7 @@ class BenchmarkResultSummary:
                             "content": value,
                             "type": field.metadata["display"],
                         }
-            formatted[result.escaped_name()] = formatted_result
+            formatted[result.name] = formatted_result
         return formatted
 
     def render_results(self):

--- a/tests/benchmarks/benchmark_result_summary.py
+++ b/tests/benchmarks/benchmark_result_summary.py
@@ -41,14 +41,14 @@ class BenchmarkResultSummary:
                 if len(values) == 0:
                     summary[name] = (0, 0)
                 else:
-                    percent_set = len(values) / len(self.results)
+                    total_set = len(values)
                     aggregation_type = field.metadata["aggregation"]
                     if aggregation_type == "sum":
-                        summary[name] = (sum(values), percent_set)
+                        summary[name] = (sum(values), total_set)
                     elif aggregation_type == "average":
-                        summary[name] = (sum(values) / len(values), percent_set)
+                        summary[name] = (sum(values) / len(values), total_set)
                     elif aggregation_type == "percent":
-                        summary[name] = (sum(values) / len(values) * 100, percent_set)
+                        summary[name] = (sum(values) / len(values) * 100, total_set)
                     elif aggregation_type == "histogram":
                         histogram = {val: values.count(val) for val in set(values)}
                         summary[name] = (histogram, len(values))
@@ -58,15 +58,16 @@ class BenchmarkResultSummary:
 
     def formatted_summary(self) -> dict[str, str]:
         formatted = {}
+        total = len(self.results)
         for field in attr.fields(BenchmarkResult):
             if "aggregation" in field.metadata:
                 name = field.name
-                value, percent_set = self.summary[name]
-                if percent_set == 0:
+                value, total_set = self.summary[name]
+                if total_set == 0:
                     continue
                 percent_set_display = ""
-                if percent_set < 1:
-                    percent_set_display = f" ({percent_set:.0%})"
+                if total_set < total:
+                    percent_set_display = f" ({total_set}/{total})"
                 formatted_value = ""
                 aggregation_type = field.metadata["aggregation"]
                 if aggregation_type == "average":

--- a/tests/benchmarks/benchmark_runner.py
+++ b/tests/benchmarks/benchmark_runner.py
@@ -181,12 +181,13 @@ async def test_benchmark(retries, benchmarks):
                 }
 
                 await client.shutdown()
+                repo.git.add(["--all"])
 
                 if hasattr(benchmark, "verify"):
                     result.verify = benchmark.verify()
 
                 # Set syntax and response grade information
-                diff = repo.git.diff()
+                diff = repo.git.diff(["--staged"])
                 result.code = diff
                 diff_grade = await grade_diff_syntax(diff)
                 result.diff_grade = diff_grade

--- a/tests/benchmarks/benchmarks/mentat/license_update.py
+++ b/tests/benchmarks/benchmarks/mentat/license_update.py
@@ -14,9 +14,9 @@ prompts = [
     'Add "HPND" second in the list of allowed licenses.',
     # This one generally fails with an off by one error. Putting HPND
     # outside of the list.
-    'Add "HPND" to the list of allowed licenses.',
+    # 'Add "HPND" to the list of allowed licenses.',
     # About half the time GPT spells out Historical Permission Notice and Disclaimer
-    "Add HPND to the list of allowed licenses.",
+    # "Add HPND to the list of allowed licenses.",
 ]
 
 repo = "https://github.com/AbanteAI/mentat"

--- a/tests/benchmarks/benchmarks/mentat/license_update.py
+++ b/tests/benchmarks/benchmarks/mentat/license_update.py
@@ -14,9 +14,9 @@ prompts = [
     'Add "HPND" second in the list of allowed licenses.',
     # This one generally fails with an off by one error. Putting HPND
     # outside of the list.
-    # 'Add "HPND" to the list of allowed licenses.',
+    'Add "HPND" to the list of allowed licenses.',
     # About half the time GPT spells out Historical Permission Notice and Disclaimer
-    # "Add HPND to the list of allowed licenses.",
+    "Add HPND to the list of allowed licenses.",
 ]
 
 repo = "https://github.com/AbanteAI/mentat"

--- a/tests/benchmarks/benchmarks/mentat/pre_tags.py
+++ b/tests/benchmarks/benchmarks/mentat/pre_tags.py
@@ -3,18 +3,18 @@ from mentat.config import Config
 title = "Pre tags around mentat output"
 
 description = """
-We changed the conversation viewer to use pre tags to display whitespace as it is outputed.
+We changed the conversation viewer to use pre tags to display white space as it is output.
 We had to set line wrap so users wouldn't have to side scroll.
 """
 
 prompts = [
-    "Change the conversation viewer to display whitespace in the messages unchanged.",
+    "Change the conversation viewer to display white space in the messages unchanged.",
     (
-        "Change the conversation viewer to display whitespace in the messages"
+        "Change the conversation viewer to display white space in the messages"
         " unchanged. Be sure the lines still wrap so side scrolling isn't necessary."
     ),
     (
-        "Remove the logic from the conversatin viewer that replaces new lines with"
+        "Remove the logic from the conversation viewer that replaces new lines with"
         " breaks and add pre tags. Set it to pre-wrap with css so side scrolling isn't"
         " necessary."
     ),

--- a/tests/benchmarks/exercise_runners/abstract_exercise_runner.py
+++ b/tests/benchmarks/exercise_runners/abstract_exercise_runner.py
@@ -1,7 +1,8 @@
-import json
 import os
 import subprocess
 from pathlib import Path
+
+from tests.benchmarks.benchmark_result import BenchmarkResult
 
 
 class AbstractExerciseRunner:
@@ -42,7 +43,7 @@ class AbstractExerciseRunner:
         with open("results.txt", "r") as f:
             for line in f.readlines():
                 if f'"{self.name}"' in line:
-                    return json.loads(line)
+                    return BenchmarkResult.from_json(line)
 
     def get_error_message(self):
         with open(self.test_output_file, "r") as f:

--- a/tests/benchmarks/exercism_practice.py
+++ b/tests/benchmarks/exercism_practice.py
@@ -1,12 +1,10 @@
 import asyncio
 import os
-import webbrowser
 from functools import partial
 from multiprocessing import Pool
 
 import pytest
 import tqdm
-from jinja2 import Environment, FileSystemLoader, select_autoescape
 from openai import BadRequestError
 
 from mentat.config import Config
@@ -234,18 +232,5 @@ def test_practice_directory_performance(
             pbar.set_description(tqdm_summary(results) + "| Last Ran: " + result.name)
         results.sort(key=lambda result: result.name)
 
-        env = Environment(
-            loader=FileSystemLoader(
-                os.path.join(
-                    os.path.dirname(__file__), "../../mentat/resources/templates"
-                )
-            ),
-            autoescape=select_autoescape(["html", "xml"]),
-        )
-        template = env.get_template("exercism_benchmark.jinja")
         summary = BenchmarkResultSummary(results)
-        rendered_html = template.render(summary=summary)
-
-        with open("results.html", "w") as f:
-            f.write(rendered_html)
-        webbrowser.open("file://" + os.path.realpath("results.html"))
+        summary.render_results()

--- a/tests/benchmarks/exercism_practice.py
+++ b/tests/benchmarks/exercism_practice.py
@@ -12,7 +12,8 @@ from openai import BadRequestError
 from mentat.config import Config
 from mentat.python_client.client import PythonClient
 from mentat.session_context import SESSION_CONTEXT
-from tests.benchmarks.benchmark_result import BenchmarkResult, BenchmarkResultSummary
+from tests.benchmarks.benchmark_result import BenchmarkResult
+from tests.benchmarks.benchmark_result_summary import BenchmarkResultSummary
 from tests.benchmarks.exercise_runners.exercise_runner_factory import (
     ExerciseRunnerFactory,
 )

--- a/tests/benchmarks/exercism_practice.py
+++ b/tests/benchmarks/exercism_practice.py
@@ -12,7 +12,7 @@ from openai import BadRequestError
 from mentat.config import Config
 from mentat.python_client.client import PythonClient
 from mentat.session_context import SESSION_CONTEXT
-from tests.benchmarks.benchmark_result import BenchmarkResult
+from tests.benchmarks.benchmark_result import BenchmarkResult, BenchmarkResultSummary
 from tests.benchmarks.exercise_runners.exercise_runner_factory import (
     ExerciseRunnerFactory,
 )
@@ -100,9 +100,6 @@ async def failure_analysis(exercise_runner, language):
 
 async def run_exercise(problem_dir, language="python", max_iterations=2):
     exercise_runner = ExerciseRunnerFactory.create(language, problem_dir)
-    old_result = exercise_runner.get_result_from_txt()
-    if old_result:
-        return old_result
     client = PythonClient(
         paths=exercise_runner.include_files(),
         exclude_paths=exercise_runner.exclude_files(),
@@ -163,6 +160,9 @@ async def run_exercise(problem_dir, language="python", max_iterations=2):
 
 def run_exercise_sync(problem_dir, language="python", max_iterations=2):
     exercise_runner = ExerciseRunnerFactory.create(language, problem_dir)
+    old_result = exercise_runner.get_result_from_txt()
+    if old_result:
+        return old_result
     try:
         result = asyncio.run(run_exercise(problem_dir, language, max_iterations))
     except Exception as e:
@@ -181,6 +181,9 @@ def run_exercise_sync(problem_dir, language="python", max_iterations=2):
     result.instructions = exercise_runner.read_instructions()
     result.code = exercise_runner.read_code(language)
     result.test_output = exercise_runner.read_test_results()
+    with open("results.txt", "a") as f:
+        f.write(result.to_json())
+        f.write("\n")
     return result
 
 
@@ -195,43 +198,6 @@ def tqdm_summary(results):
         else:
             failed += 1
     return "Passed: " + str(passed_in_n)[1:-1] + "| Failed: " + str(failed)
-
-
-def results_summary(results):
-    results_map = {}
-    passedIterations = {}
-    reasons = {}
-    passed = 0
-    failed = 0
-    tokens = 0
-    cost = 0
-    totalIterations = 0
-
-    for result in results:
-        name = result.name
-        cost += result.cost
-        results_map[name] = result
-        if result.passed:
-            passed += 1
-            iterations = result.iterations
-            passedIterations[iterations] = passedIterations.get(iterations, 0) + 1
-            tokens += result.tokens
-            totalIterations += iterations
-        else:
-            failed += 1
-            reason = result.reason
-            reasons[reason] = reasons.get(reason, 0) + 1
-
-    avgTokens = tokens // totalIterations if totalIterations > 0 else 0
-    return {
-        "cost": cost,
-        "results_map": results_map,
-        "passedIterations": passedIterations,
-        "reasons": reasons,
-        "passed": passed,
-        "failed": failed,
-        "avgTokens": avgTokens,
-    }
 
 
 def test_practice_directory_performance(
@@ -264,9 +230,6 @@ def test_practice_directory_performance(
         for result in result_map:
             pbar.update()
             results.append(result)
-            with open("results.txt", "a") as f:
-                f.write(result.to_json())
-                f.write("\n")
             pbar.set_description(tqdm_summary(results) + "| Last Ran: " + result.name)
         results.sort(key=lambda result: result.name)
 
@@ -279,7 +242,7 @@ def test_practice_directory_performance(
             autoescape=select_autoescape(["html", "xml"]),
         )
         template = env.get_template("exercism_benchmark.jinja")
-        summary = results_summary(results)
+        summary = BenchmarkResultSummary(results)
         rendered_html = template.render(summary=summary)
 
         with open("results.html", "w") as f:


### PR DESCRIPTION
The BenchmarkResult class and it's viewer are made more general with the following changes:
* Attributes of a benchmark result can be marked aggregateable and if they are the summary will compute and display the appropriate statistic for them: average, percent, sum. The property is not displayed if it is none for all benchmarks. If only a a subset of the benchmarks define it the percent is given in parenthesis next to the aggregated number.
* Attributes of a benchmark can specify how they should be displayed: text, code, transcript or json.
Now if you introduce a new benchmark with a new property you can add the property to the BenchmarkResults class along with the appropriate metadata. This won't break previous benchmarks and if appropriate it is easy to set it for them.

misc:
* previously the data was rewritten to txt on multiple runs. This is fixed.
* Rendering the summary is done by the summary.

todo:
* [x] actually use it in the benchmark runner.
* [x] Aggregate indentation/syntax errors.
* [x] Have the jinja template iterate over non-aggregated display properties instead hard coding.
* [x] Group exercises in the selector. So exercises that differ only by prompt or are just repeat iterations are together.
* [x] When a field represents an aggregation of a subset denote that with parenthesis.