### PR TITLE
fix inner git repository bug

### DIFF
--- a/mentat/code_context.py
+++ b/mentat/code_context.py
@@ -359,11 +359,11 @@ class CodeContext:
             return included_paths
 
         for code_feature in code_features:
-            # Path in included files
+            # Path not in included files
             if code_feature.path not in self.include_files:
                 self.include_files[code_feature.path] = [code_feature]
                 included_paths.add(Path(code_feature.ref()))
-            # Path not in included files
+            # Path in included files
             else:
                 code_feature_not_included = True
                 # NOTE: should have CodeFeatures in a hashtable

--- a/mentat/git_handler.py
+++ b/mentat/git_handler.py
@@ -8,7 +8,7 @@ from mentat.errors import UserError
 from mentat.session_context import SESSION_CONTEXT
 
 
-def get_non_gitignored_files(root: Path) -> Set[Path]:
+def get_non_gitignored_files(root: Path, visited: set[Path] = set()) -> Set[Path]:
     paths = set(
         # git returns / separated paths even on windows, convert so we can remove
         # glob_excluded_files, which have windows paths on windows
@@ -28,13 +28,17 @@ def get_non_gitignored_files(root: Path) -> Set[Path]:
     )
 
     file_paths: Set[Path] = set()
+    # We use visited to make sure we break out of any infinite loops symlinks might cause
+    visited.add(root.resolve())
     for path in paths:
         # git ls-files returns directories if the directory is itself a git project;
         # so we recursively run this function on any directories it returns.
         if (root / path).is_dir():
+            if (root / path).resolve() in visited:
+                continue
             file_paths.update(
                 root / path / inner_path
-                for inner_path in get_non_gitignored_files(root / path)
+                for inner_path in get_non_gitignored_files(root / path, visited)
             )
         else:
             file_paths.add(path)

--- a/mentat/git_handler.py
+++ b/mentat/git_handler.py
@@ -2,14 +2,14 @@ import logging
 import os
 import subprocess
 from pathlib import Path
-from typing import Optional
+from typing import Optional, Set
 
 from mentat.errors import UserError
 from mentat.session_context import SESSION_CONTEXT
 
 
-def get_non_gitignored_files(path: Path) -> set[Path]:
-    return set(
+def get_non_gitignored_files(root: Path) -> Set[Path]:
+    paths = set(
         # git returns / separated paths even on windows, convert so we can remove
         # glob_excluded_files, which have windows paths on windows
         Path(os.path.normpath(p))
@@ -18,14 +18,27 @@ def get_non_gitignored_files(path: Path) -> set[Path]:
             subprocess.check_output(
                 # -c shows cached (regular) files, -o shows other (untracked/new) files
                 ["git", "ls-files", "-c", "-o", "--exclude-standard"],
-                cwd=path,
+                cwd=root,
                 text=True,
                 stderr=subprocess.DEVNULL,
             ).split("\n"),
         )
         # windows-safe check if p exists in path
-        if Path(path / p).exists()
+        if Path(root / p).exists()
     )
+
+    file_paths: Set[Path] = set()
+    for path in paths:
+        # git ls-files returns directories if the directory is itself a git project;
+        # so we recursively run this function on any directories it returns.
+        if (root / path).is_dir():
+            file_paths.update(
+                root / path / inner_path
+                for inner_path in get_non_gitignored_files(root / path)
+            )
+        else:
+            file_paths.add(path)
+    return file_paths
 
 
 def get_paths_with_git_diffs(git_root: Path) -> set[Path]:

--- a/mentat/include_files.py
+++ b/mentat/include_files.py
@@ -210,7 +210,7 @@ def get_paths_for_directory(
             dirs[:] = list[str]()
             git_non_gitignored_paths = get_non_gitignored_files(root)
             for git_path in git_non_gitignored_paths:
-                abs_git_path = root.joinpath(git_path)
+                abs_git_path = root / git_path
                 if not recursive and git_path.parent != Path("."):
                     continue
                 if any(include_patterns) and not match_path_with_patterns(
@@ -252,7 +252,7 @@ def get_paths_for_directory(
 
             if not recursive:
                 break
-    paths = set(filter(is_file_text_encoded, paths))
+    paths = set(p.resolve() for p in paths if is_file_text_encoded(p))
 
     return paths
 


### PR DESCRIPTION
Fixes #393. Turns out git ls-files returns directories instead of files for any inner git repositories it finds!