### PR TITLE
Add initial basic Sphinx documentation 

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -6,3 +6,6 @@ pip-licenses==4.3.3
 pyright==1.1.339
 pytest-xdist==3.3.1
 ruff==0.0.292
+sphinx==7.2.6
+sphinx-rtd-theme==2.0.0
+

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -1,0 +1,20 @@
+# Minimal makefile for Sphinx documentation
+#
+
+# You can set these variables from the command line, and also
+# from the environment for the first two.
+SPHINXOPTS    ?=
+SPHINXBUILD   ?= sphinx-build
+SOURCEDIR     = source
+BUILDDIR      = build
+
+# Put it first so that "make" without argument is like "make help".
+help:
+	@$(SPHINXBUILD) -M help "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)
+
+.PHONY: help Makefile
+
+# Catch-all target: route all unknown targets to Sphinx using the new
+# "make mode" option.  $(O) is meant as a shortcut for $(SPHINXOPTS).
+%: Makefile
+	@$(SPHINXBUILD) -M $@ "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)

--- a/docs/make.bat
+++ b/docs/make.bat
@@ -1,0 +1,35 @@
+@ECHO OFF
+
+pushd %~dp0
+
+REM Command file for Sphinx documentation
+
+if "%SPHINXBUILD%" == "" (
+	set SPHINXBUILD=sphinx-build
+)
+set SOURCEDIR=source
+set BUILDDIR=build
+
+%SPHINXBUILD% >NUL 2>NUL
+if errorlevel 9009 (
+	echo.
+	echo.The 'sphinx-build' command was not found. Make sure you have Sphinx
+	echo.installed, then set the SPHINXBUILD environment variable to point
+	echo.to the full path of the 'sphinx-build' executable. Alternatively you
+	echo.may add the Sphinx directory to PATH.
+	echo.
+	echo.If you don't have Sphinx installed, grab it from
+	echo.https://www.sphinx-doc.org/
+	exit /b 1
+)
+
+if "%1" == "" goto help
+
+%SPHINXBUILD% -M %1 %SOURCEDIR% %BUILDDIR% %SPHINXOPTS% %O%
+goto end
+
+:help
+%SPHINXBUILD% -M help %SOURCEDIR% %BUILDDIR% %SPHINXOPTS% %O%
+
+:end
+popd

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -3,8 +3,8 @@
 # For the full list of built-in configuration values, see the documentation:
 # https://www.sphinx-doc.org/en/master/usage/configuration.html
 
-import sys
 import os
+import sys
 
 # -- Project information -----------------------------------------------------
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#project-information

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -1,0 +1,37 @@
+# Configuration file for the Sphinx documentation builder.
+#
+# For the full list of built-in configuration values, see the documentation:
+# https://www.sphinx-doc.org/en/master/usage/configuration.html
+
+# -- Project information -----------------------------------------------------
+# https://www.sphinx-doc.org/en/master/usage/configuration.html#project-information
+
+project = 'Mentat'
+copyright = '2023, Multiple Authors'
+author = 'Multiple Authors'
+release = '1.0.6'
+
+# -- General configuration ---------------------------------------------------
+# https://www.sphinx-doc.org/en/master/usage/configuration.html#general-configuration
+
+extensions = [
+'sphinx.ext.autodoc',
+'sphinx.ext.viewcode',
+'sphinx.ext.napoleon'
+]
+
+templates_path = ['_templates']
+exclude_patterns = []
+
+
+
+# -- Options for HTML output -------------------------------------------------
+# https://www.sphinx-doc.org/en/master/usage/configuration.html#options-for-html-output
+
+html_theme = 'sphinx_rtd_theme'
+html_static_path = ['_static']
+
+
+# AXJ
+import sys, os
+sys.path.insert(0, os.path.abspath('../..'))

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -10,7 +10,7 @@ import sys
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#project-information
 
 project = "Mentat"
-copyright = "2023, Multiple Authors"
+copyright = "2023, Abante AI"
 author = "Multiple Authors"
 release = "1.0.6"
 

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -3,6 +3,9 @@
 # For the full list of built-in configuration values, see the documentation:
 # https://www.sphinx-doc.org/en/master/usage/configuration.html
 
+import sys
+import os
+
 # -- Project information -----------------------------------------------------
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#project-information
 
@@ -34,5 +37,4 @@ html_static_path = ['_static']
 
 
 # AXJ
-import sys, os
 sys.path.insert(0, os.path.abspath('../..'))

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -17,7 +17,8 @@ release = '1.0.6'
 extensions = [
 'sphinx.ext.autodoc',
 'sphinx.ext.viewcode',
-'sphinx.ext.napoleon'
+'sphinx.ext.napoleon',
+'sphinx.ext.todo'
 ]
 
 templates_path = ['_templates']

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -9,32 +9,31 @@ import os
 # -- Project information -----------------------------------------------------
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#project-information
 
-project = 'Mentat'
-copyright = '2023, Multiple Authors'
-author = 'Multiple Authors'
-release = '1.0.6'
+project = "Mentat"
+copyright = "2023, Multiple Authors"
+author = "Multiple Authors"
+release = "1.0.6"
 
 # -- General configuration ---------------------------------------------------
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#general-configuration
 
 extensions = [
-'sphinx.ext.autodoc',
-'sphinx.ext.viewcode',
-'sphinx.ext.napoleon',
-'sphinx.ext.todo'
+    "sphinx.ext.autodoc",
+    "sphinx.ext.viewcode",
+    "sphinx.ext.napoleon",
+    "sphinx.ext.todo",
 ]
 
-templates_path = ['_templates']
+templates_path = ["_templates"]
 exclude_patterns = []
-
 
 
 # -- Options for HTML output -------------------------------------------------
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#options-for-html-output
 
-html_theme = 'sphinx_rtd_theme'
-html_static_path = ['_static']
+html_theme = "sphinx_rtd_theme"
+html_static_path = ["_static"]
 
 
 # AXJ
-sys.path.insert(0, os.path.abspath('../..'))
+sys.path.insert(0, os.path.abspath("../.."))

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -1,0 +1,20 @@
+.. Mentat documentation master file, created by
+   sphinx-quickstart on Mon Dec 18 14:03:42 2023.
+   You can adapt this file completely to your liking, but it should at least
+   contain the root `toctree` directive.
+
+Welcome to Mentat's documentation!
+==================================
+
+.. toctree::
+   :maxdepth: 2
+   :caption: Contents:
+
+
+
+Indices and tables
+==================
+
+* :ref:`genindex`
+* :ref:`modindex`
+* :ref:`search`

--- a/docs/source/mentat.command.commands.rst
+++ b/docs/source/mentat.command.commands.rst
@@ -1,0 +1,141 @@
+mentat.command.commands package
+===============================
+
+Submodules
+----------
+
+mentat.command.commands.agent module
+------------------------------------
+
+.. automodule:: mentat.command.commands.agent
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+mentat.command.commands.clear module
+------------------------------------
+
+.. automodule:: mentat.command.commands.clear
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+mentat.command.commands.commit module
+-------------------------------------
+
+.. automodule:: mentat.command.commands.commit
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+mentat.command.commands.config module
+-------------------------------------
+
+.. automodule:: mentat.command.commands.config
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+mentat.command.commands.context module
+--------------------------------------
+
+.. automodule:: mentat.command.commands.context
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+mentat.command.commands.exclude module
+--------------------------------------
+
+.. automodule:: mentat.command.commands.exclude
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+mentat.command.commands.help module
+-----------------------------------
+
+.. automodule:: mentat.command.commands.help
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+mentat.command.commands.include module
+--------------------------------------
+
+.. automodule:: mentat.command.commands.include
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+mentat.command.commands.redo module
+-----------------------------------
+
+.. automodule:: mentat.command.commands.redo
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+mentat.command.commands.run module
+----------------------------------
+
+.. automodule:: mentat.command.commands.run
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+mentat.command.commands.screenshot module
+-----------------------------------------
+
+.. automodule:: mentat.command.commands.screenshot
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+mentat.command.commands.search module
+-------------------------------------
+
+.. automodule:: mentat.command.commands.search
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+mentat.command.commands.talk module
+-----------------------------------
+
+.. automodule:: mentat.command.commands.talk
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+mentat.command.commands.undo module
+-----------------------------------
+
+.. automodule:: mentat.command.commands.undo
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+mentat.command.commands.undoall module
+--------------------------------------
+
+.. automodule:: mentat.command.commands.undoall
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+mentat.command.commands.viewer module
+-------------------------------------
+
+.. automodule:: mentat.command.commands.viewer
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+Module contents
+---------------
+
+.. automodule:: mentat.command.commands
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/mentat.command.rst
+++ b/docs/source/mentat.command.rst
@@ -1,0 +1,29 @@
+mentat.command package
+======================
+
+Subpackages
+-----------
+
+.. toctree::
+   :maxdepth: 4
+
+   mentat.command.commands
+
+Submodules
+----------
+
+mentat.command.command module
+-----------------------------
+
+.. automodule:: mentat.command.command
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+Module contents
+---------------
+
+.. automodule:: mentat.command
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/mentat.feature_filters.rst
+++ b/docs/source/mentat.feature_filters.rst
@@ -1,0 +1,61 @@
+mentat.feature\_filters package
+===============================
+
+Submodules
+----------
+
+mentat.feature\_filters.default\_filter module
+----------------------------------------------
+
+.. automodule:: mentat.feature_filters.default_filter
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+mentat.feature\_filters.embedding\_similarity\_filter module
+------------------------------------------------------------
+
+.. automodule:: mentat.feature_filters.embedding_similarity_filter
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+mentat.feature\_filters.feature\_filter module
+----------------------------------------------
+
+.. automodule:: mentat.feature_filters.feature_filter
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+mentat.feature\_filters.llm\_feature\_filter module
+---------------------------------------------------
+
+.. automodule:: mentat.feature_filters.llm_feature_filter
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+mentat.feature\_filters.truncate\_filter module
+-----------------------------------------------
+
+.. automodule:: mentat.feature_filters.truncate_filter
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+mentat.feature\_filters.user\_include\_sort\_filter module
+----------------------------------------------------------
+
+.. automodule:: mentat.feature_filters.user_include_sort_filter
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+Module contents
+---------------
+
+.. automodule:: mentat.feature_filters
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/mentat.parsers.rst
+++ b/docs/source/mentat.parsers.rst
@@ -1,0 +1,93 @@
+mentat.parsers package
+======================
+
+Submodules
+----------
+
+mentat.parsers.block\_parser module
+-----------------------------------
+
+.. automodule:: mentat.parsers.block_parser
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+mentat.parsers.change\_display\_helper module
+---------------------------------------------
+
+.. automodule:: mentat.parsers.change_display_helper
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+mentat.parsers.diff\_utils module
+---------------------------------
+
+.. automodule:: mentat.parsers.diff_utils
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+mentat.parsers.file\_edit module
+--------------------------------
+
+.. automodule:: mentat.parsers.file_edit
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+mentat.parsers.git\_parser module
+---------------------------------
+
+.. automodule:: mentat.parsers.git_parser
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+mentat.parsers.json\_parser module
+----------------------------------
+
+.. automodule:: mentat.parsers.json_parser
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+mentat.parsers.parser module
+----------------------------
+
+.. automodule:: mentat.parsers.parser
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+mentat.parsers.parser\_map module
+---------------------------------
+
+.. automodule:: mentat.parsers.parser_map
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+mentat.parsers.replacement\_parser module
+-----------------------------------------
+
+.. automodule:: mentat.parsers.replacement_parser
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+mentat.parsers.unified\_diff\_parser module
+-------------------------------------------
+
+.. automodule:: mentat.parsers.unified_diff_parser
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+Module contents
+---------------
+
+.. automodule:: mentat.parsers
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/mentat.prompts.rst
+++ b/docs/source/mentat.prompts.rst
@@ -1,0 +1,21 @@
+mentat.prompts package
+======================
+
+Submodules
+----------
+
+mentat.prompts.prompts module
+-----------------------------
+
+.. automodule:: mentat.prompts.prompts
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+Module contents
+---------------
+
+.. automodule:: mentat.prompts
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/mentat.python_client.rst
+++ b/docs/source/mentat.python_client.rst
@@ -1,0 +1,21 @@
+mentat.python\_client package
+=============================
+
+Submodules
+----------
+
+mentat.python\_client.client module
+-----------------------------------
+
+.. automodule:: mentat.python_client.client
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+Module contents
+---------------
+
+.. automodule:: mentat.python_client
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/mentat.rst
+++ b/docs/source/mentat.rst
@@ -1,0 +1,259 @@
+mentat package
+==============
+
+Subpackages
+-----------
+
+.. toctree::
+   :maxdepth: 4
+
+   mentat.command
+   mentat.feature_filters
+   mentat.parsers
+   mentat.prompts
+   mentat.python_client
+   mentat.terminal
+   mentat.vision
+
+Submodules
+----------
+
+mentat.agent\_handler module
+----------------------------
+
+.. automodule:: mentat.agent_handler
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+mentat.app\_conf module
+-----------------------
+
+.. automodule:: mentat.app_conf
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+mentat.auto\_completer module
+-----------------------------
+
+.. automodule:: mentat.auto_completer
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+mentat.broadcast module
+-----------------------
+
+.. automodule:: mentat.broadcast
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+mentat.code\_context module
+---------------------------
+
+.. automodule:: mentat.code_context
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+mentat.code\_edit\_feedback module
+----------------------------------
+
+.. automodule:: mentat.code_edit_feedback
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+mentat.code\_feature module
+---------------------------
+
+.. automodule:: mentat.code_feature
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+mentat.code\_file\_manager module
+---------------------------------
+
+.. automodule:: mentat.code_file_manager
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+mentat.config module
+--------------------
+
+.. automodule:: mentat.config
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+mentat.conversation module
+--------------------------
+
+.. automodule:: mentat.conversation
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+mentat.cost\_tracker module
+---------------------------
+
+.. automodule:: mentat.cost_tracker
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+mentat.ctags module
+-------------------
+
+.. automodule:: mentat.ctags
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+mentat.diff\_context module
+---------------------------
+
+.. automodule:: mentat.diff_context
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+mentat.edit\_history module
+---------------------------
+
+.. automodule:: mentat.edit_history
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+mentat.embeddings module
+------------------------
+
+.. automodule:: mentat.embeddings
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+mentat.errors module
+--------------------
+
+.. automodule:: mentat.errors
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+mentat.git\_handler module
+--------------------------
+
+.. automodule:: mentat.git_handler
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+mentat.include\_files module
+----------------------------
+
+.. automodule:: mentat.include_files
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+mentat.interval module
+----------------------
+
+.. automodule:: mentat.interval
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+mentat.llm\_api\_handler module
+-------------------------------
+
+.. automodule:: mentat.llm_api_handler
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+mentat.logging\_config module
+-----------------------------
+
+.. automodule:: mentat.logging_config
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+mentat.sentry module
+--------------------
+
+.. automodule:: mentat.sentry
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+mentat.session module
+---------------------
+
+.. automodule:: mentat.session
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+mentat.session\_context module
+------------------------------
+
+.. automodule:: mentat.session_context
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+mentat.session\_input module
+----------------------------
+
+.. automodule:: mentat.session_input
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+mentat.session\_stream module
+-----------------------------
+
+.. automodule:: mentat.session_stream
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+mentat.streaming\_printer module
+--------------------------------
+
+.. automodule:: mentat.streaming_printer
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+mentat.transcripts module
+-------------------------
+
+.. automodule:: mentat.transcripts
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+mentat.utils module
+-------------------
+
+.. automodule:: mentat.utils
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+Module contents
+---------------
+
+.. automodule:: mentat
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/mentat.terminal.rst
+++ b/docs/source/mentat.terminal.rst
@@ -1,0 +1,53 @@
+mentat.terminal package
+=======================
+
+Submodules
+----------
+
+mentat.terminal.client module
+-----------------------------
+
+.. automodule:: mentat.terminal.client
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+mentat.terminal.loading module
+------------------------------
+
+.. automodule:: mentat.terminal.loading
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+mentat.terminal.output module
+-----------------------------
+
+.. automodule:: mentat.terminal.output
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+mentat.terminal.prompt\_completer module
+----------------------------------------
+
+.. automodule:: mentat.terminal.prompt_completer
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+mentat.terminal.prompt\_session module
+--------------------------------------
+
+.. automodule:: mentat.terminal.prompt_session
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+Module contents
+---------------
+
+.. automodule:: mentat.terminal
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/mentat.vision.rst
+++ b/docs/source/mentat.vision.rst
@@ -1,0 +1,21 @@
+mentat.vision package
+=====================
+
+Submodules
+----------
+
+mentat.vision.vision\_manager module
+------------------------------------
+
+.. automodule:: mentat.vision.vision_manager
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+Module contents
+---------------
+
+.. automodule:: mentat.vision
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/modules.rst
+++ b/docs/source/modules.rst
@@ -1,0 +1,7 @@
+mentat
+======
+
+.. toctree::
+   :maxdepth: 4
+
+   mentat

--- a/mentat/session_input.py
+++ b/mentat/session_input.py
@@ -77,9 +77,9 @@ async def listen_for_interrupt(
     asyncio.Task created from `coro` will be canceled.
 
     TODO:
-    - make sure task cancellation actually cancels the tasks
+      - make sure task cancellation actually cancels the tasks
       - Is there any kind of delay, or a possiblity of one?
-    - make sure there's no race conditions
+      - make sure there's no race conditions
 
     The `.result()` call for `wrapped_task` will re-raise any exceptions thrown
     inside of that Task.

--- a/requirements.txt
+++ b/requirements.txt
@@ -22,3 +22,5 @@ tiktoken==0.4.0
 typing_extensions==4.8.0
 tqdm==4.66.1
 webdriver_manager==4.0.1
+sphinx
+sphinx-rtd-theme

--- a/requirements.txt
+++ b/requirements.txt
@@ -22,5 +22,3 @@ tiktoken==0.4.0
 typing_extensions==4.8.0
 tqdm==4.66.1
 webdriver_manager==4.0.1
-sphinx
-sphinx-rtd-theme


### PR DESCRIPTION
Add the basic Sphinx setup to create documentation for the mentat module. This is done by

- Creating the docs/source directory, adding in the mininmal required sphinx code (using sphinx-quickstart and sphinx-apidocs).
- Change the theme to sphinx_rtd_theme.

To generate the documents change to the docs folder and run the commane
`make clean html`

The resulting dpcumentation will be in the docs/build directory and can be viewed using your browser e.g. `firefox docs/build/html/index.html`