### PR TITLE
Files outside cwd can be edited

### DIFF
--- a/mentat/code_file_manager.py
+++ b/mentat/code_file_manager.py
@@ -102,7 +102,7 @@ class CodeFileManager:
                 continue
 
             if not file_edit.is_creation:
-                stored_lines = self.file_lines[file_edit.file_path]
+                stored_lines = self.get_file_lines(file_edit)
                 if stored_lines != self.read_file(file_edit.file_path):
                     logging.info(
                         f"File '{file_edit.file_path}' changed while generating changes"
@@ -152,3 +152,7 @@ class CodeFileManager:
             ]
             text = "\n".join(filtered_lines)
         return sha256(text)
+
+    def get_file_lines(self, file_edit: FileEdit) -> list[str]:
+        path = file_edit.file_path.resolve()
+        return self.file_lines[path]

--- a/mentat/code_file_manager.py
+++ b/mentat/code_file_manager.py
@@ -102,7 +102,7 @@ class CodeFileManager:
                 continue
 
             if not file_edit.is_creation:
-                stored_lines = self.get_file_lines(file_edit)
+                stored_lines = self.file_lines[file_edit.file_path]
                 if stored_lines != self.read_file(file_edit.file_path):
                     logging.info(
                         f"File '{file_edit.file_path}' changed while generating changes"
@@ -152,7 +152,3 @@ class CodeFileManager:
             ]
             text = "\n".join(filtered_lines)
         return sha256(text)
-
-    def get_file_lines(self, file_edit: FileEdit) -> list[str]:
-        path = file_edit.file_path.resolve()
-        return self.file_lines[path]

--- a/mentat/parsers/block_parser.py
+++ b/mentat/parsers/block_parser.py
@@ -149,8 +149,16 @@ class BlockParser(Parser):
         if ending_line < starting_line:
             raise ModelError("Error: Model output malformed edit.")
 
+        full_path = (cwd / deserialized_json.file).resolve()
+        rename_file_path = (
+                (cwd / deserialized_json.name).resolve()
+                if deserialized_json.name
+                else None
+                )
+
+
         file_lines = self._get_file_lines(
-            code_file_manager, rename_map, deserialized_json.file
+            code_file_manager, rename_map, full_path
         )
         display_information = DisplayInformation(
             deserialized_json.file,
@@ -167,15 +175,11 @@ class BlockParser(Parser):
         if deserialized_json.action == _BlockParserAction.Delete:
             replacements.append(Replacement(starting_line, ending_line, []))
         file_edit = FileEdit(
-            (cwd / deserialized_json.file).resolve(),
+            full_path,
             replacements,
             is_creation=file_action == FileActionType.CreateFile,
             is_deletion=file_action == FileActionType.DeleteFile,
-            rename_file_path=(
-                (cwd / deserialized_json.name).resolve()
-                if deserialized_json.name
-                else None
-            ),
+            rename_file_path=rename_file_path,
         )
         has_code = block[-1] == _BlockParserIndicator.Code.value
         return (display_information, file_edit, has_code)

--- a/mentat/parsers/block_parser.py
+++ b/mentat/parsers/block_parser.py
@@ -167,12 +167,14 @@ class BlockParser(Parser):
         if deserialized_json.action == _BlockParserAction.Delete:
             replacements.append(Replacement(starting_line, ending_line, []))
         file_edit = FileEdit(
-            cwd / deserialized_json.file,
+            (cwd / deserialized_json.file).resolve(),
             replacements,
             is_creation=file_action == FileActionType.CreateFile,
             is_deletion=file_action == FileActionType.DeleteFile,
             rename_file_path=(
-                cwd / deserialized_json.name if deserialized_json.name else None
+                (cwd / deserialized_json.name).resolve()
+                if deserialized_json.name
+                else None
             ),
         )
         has_code = block[-1] == _BlockParserIndicator.Code.value

--- a/mentat/parsers/block_parser.py
+++ b/mentat/parsers/block_parser.py
@@ -151,15 +151,10 @@ class BlockParser(Parser):
 
         full_path = (cwd / deserialized_json.file).resolve()
         rename_file_path = (
-                (cwd / deserialized_json.name).resolve()
-                if deserialized_json.name
-                else None
-                )
-
-
-        file_lines = self._get_file_lines(
-            code_file_manager, rename_map, full_path
+            (cwd / deserialized_json.name).resolve() if deserialized_json.name else None
         )
+
+        file_lines = self._get_file_lines(code_file_manager, rename_map, full_path)
         display_information = DisplayInformation(
             deserialized_json.file,
             file_lines,

--- a/mentat/parsers/git_parser.py
+++ b/mentat/parsers/git_parser.py
@@ -51,7 +51,7 @@ class GitParser:
                 new_name = None
 
             file_edit = FileEdit(
-                session_context.cwd / start_file_name,
+                (session_context.cwd / start_file_name).resolve(),
                 [],
                 is_creation=is_creation,
                 is_deletion=is_deletion,

--- a/mentat/parsers/json_parser.py
+++ b/mentat/parsers/json_parser.py
@@ -143,7 +143,7 @@ class JsonParser(Parser):
 
         file_edits: Dict[Path, FileEdit] = {}
         for obj in response_json["content"]:
-            filename = session_context.cwd / obj.get("filename", "")
+            filename = (session_context.cwd / obj.get("filename", "")).resolve()
             if filename in rename_map:
                 filename = rename_map[filename]
             match obj["type"]:

--- a/mentat/parsers/parser.py
+++ b/mentat/parsers/parser.py
@@ -218,14 +218,11 @@ class Parser(ABC):
                         cur_block = ""
 
                         # Rename map handling
-                        if display_information.new_name is not None:
-                            rename_map[display_information.new_name] = (
-                                display_information.file_name
-                            )
-                        if display_information.file_name in rename_map:
+                        if file_edit.rename_file_path is not None:
+                            rename_map[file_edit.rename_file_path] = file_edit.file_path
+                        if file_edit.file_path in rename_map:
                             file_edit.file_path = (
-                                session_context.cwd
-                                / rename_map[display_information.file_name]
+                                session_context.cwd / rename_map[file_edit.file_path]
                             )
 
                         # New file_edit creation and merging
@@ -332,15 +329,13 @@ class Parser(ABC):
         self,
         code_file_manager: CodeFileManager,
         rename_map: dict[Path, Path],
-        rel_path: Path,
+        abs_path: Path,
     ) -> list[str]:
-        ctx = SESSION_CONTEXT.get()
-
         path = rename_map.get(
-            rel_path,
-            rel_path,
+            abs_path,
+            abs_path,
         )
-        return code_file_manager.file_lines.get(ctx.cwd / path, [])
+        return code_file_manager.file_lines.get(path, [])
 
     # These methods aren't abstract, since most parsers will use this implementation, but can be overriden easily
     def provide_line_numbers(self) -> bool:

--- a/mentat/parsers/replacement_parser.py
+++ b/mentat/parsers/replacement_parser.py
@@ -43,7 +43,8 @@ class ReplacementParser(Parser):
             raise ModelError("Error: Invalid model output")
 
         file_name = Path(info[0])
-        file_lines = self._get_file_lines(code_file_manager, rename_map, file_name)
+        full_path = (cwd / file_name).resolve()
+        file_lines = self._get_file_lines(code_file_manager, rename_map, full_path)
         new_name = None
 
         # For an insert, just make the second number 1 less than the starting line (since we sub 1 from starting line)
@@ -89,7 +90,7 @@ class ReplacementParser(Parser):
         )
 
         file_edit = FileEdit(
-            (cwd / file_name).resolve(),
+            full_path,
             [],
             is_creation=file_action_type == FileActionType.CreateFile,
             is_deletion=file_action_type == FileActionType.DeleteFile,

--- a/mentat/parsers/replacement_parser.py
+++ b/mentat/parsers/replacement_parser.py
@@ -89,11 +89,11 @@ class ReplacementParser(Parser):
         )
 
         file_edit = FileEdit(
-            cwd / file_name,
+            (cwd / file_name).resolve(),
             [],
             is_creation=file_action_type == FileActionType.CreateFile,
             is_deletion=file_action_type == FileActionType.DeleteFile,
-            rename_file_path=cwd / new_name if new_name else None,
+            rename_file_path=(cwd / new_name).resolve() if new_name else None,
         )
         has_code = file_action_type == FileActionType.UpdateFile
         return (display_information, file_edit, has_code)

--- a/mentat/parsers/unified_diff_parser.py
+++ b/mentat/parsers/unified_diff_parser.py
@@ -102,13 +102,14 @@ class UnifiedDiffParser(Parser):
         else:
             new_name = Path(new_name)
         file_name = Path(file_name)
-        file_lines = self._get_file_lines(code_file_manager, rename_map, file_name)
+        full_path = (cwd / file_name).resolve()
+        file_lines = self._get_file_lines(code_file_manager, rename_map, full_path)
         file_action_type = get_file_action_type(is_creation, is_deletion, new_name)
         display_information = DisplayInformation(
             file_name, file_lines, [], [], file_action_type, -1, -1, new_name
         )
         file_edit = FileEdit(
-            (cwd / file_name).resolve(),
+            full_path,
             [],
             is_creation,
             is_deletion,

--- a/mentat/parsers/unified_diff_parser.py
+++ b/mentat/parsers/unified_diff_parser.py
@@ -108,11 +108,11 @@ class UnifiedDiffParser(Parser):
             file_name, file_lines, [], [], file_action_type, -1, -1, new_name
         )
         file_edit = FileEdit(
-            cwd / file_name,
+            (cwd / file_name).resolve(),
             [],
             is_creation,
             is_deletion,
-            cwd / new_name if new_name else None,
+            (cwd / new_name).resolve() if new_name else None,
         )
         return (
             display_information,

--- a/mentat/parsers/unified_diff_parser.py
+++ b/mentat/parsers/unified_diff_parser.py
@@ -136,7 +136,7 @@ class UnifiedDiffParser(Parser):
         file_edit: FileEdit,
     ) -> str:
         file_lines = self._get_file_lines(
-            code_file_manager, rename_map, display_information.file_name
+            code_file_manager, rename_map, file_edit.file_path
         ).copy()
 
         # First, we split by the symbols that separate changes.

--- a/mentat/python_client/client.py
+++ b/mentat/python_client/client.py
@@ -20,7 +20,7 @@ class PythonClient:
         pr_diff: str | None = None,
         config: Config = Config(),
     ):
-        self.cwd = cwd.resolve()
+        self.cwd = cwd.expanduser().resolve()
         self.paths = paths
         self.exclude_paths = exclude_paths
         self.ignore_paths = ignore_paths

--- a/mentat/python_client/client.py
+++ b/mentat/python_client/client.py
@@ -20,7 +20,7 @@ class PythonClient:
         pr_diff: str | None = None,
         config: Config = Config(),
     ):
-        self.cwd = cwd
+        self.cwd = cwd.resolve()
         self.paths = paths
         self.exclude_paths = exclude_paths
         self.ignore_paths = ignore_paths

--- a/mentat/terminal/client.py
+++ b/mentat/terminal/client.py
@@ -244,7 +244,7 @@ def run_cli():
     Config.add_fields_to_argparse(parser)
     args = parser.parse_args()
 
-    cwd = args.cwd
+    cwd = Path(args.cwd).resolve()
     paths = args.paths
     exclude_paths = args.exclude
     ignore_paths = args.ignore

--- a/mentat/terminal/client.py
+++ b/mentat/terminal/client.py
@@ -244,7 +244,7 @@ def run_cli():
     Config.add_fields_to_argparse(parser)
     args = parser.parse_args()
 
-    cwd = Path(args.cwd).resolve()
+    cwd = Path(args.cwd).expanduser().resolve()
     paths = args.paths
     exclude_paths = args.exclude
     ignore_paths = args.ignore

--- a/tests/code_file_manager_test.py
+++ b/tests/code_file_manager_test.py
@@ -114,6 +114,64 @@ async def test_run_from_subdirectory(
 
 
 @pytest.mark.asyncio
+async def test_run_from_superdirectory(
+    temp_testbed,
+    mock_collect_user_input,
+    mock_call_llm_api,
+):
+    """Run mentat from outside the git root"""
+    # Change to the subdirectory
+    mock_collect_user_input.set_stream_messages(
+        [
+            (
+                "Insert the comment # Hello on the first line of"
+                " multifile_calculator/calculator.py and scripts/echo.py"
+            ),
+            "y",
+            "q",
+        ]
+    )
+    mock_call_llm_api.set_streamed_values([dedent("""\
+        I will insert a comment in both files.
+
+        @@start
+        {
+            "file": "../multifile_calculator/calculator.py",
+            "action": "insert",
+            "insert-after-line": 0,
+            "insert-before-line": 1
+        }
+        @@code
+        # Hello
+        @@end
+        @@start
+        {
+            "file": "../scripts/echo.py",
+            "action": "insert",
+            "insert-after-line": 0,
+            "insert-before-line": 1
+        }
+        @@code
+        # Hello
+        @@end""")])
+
+    session = Session(
+        cwd=Path(temp_testbed) / "format_examples",
+        paths=["../multifile_calculator/calculator.py", "../scripts"],
+    )
+    session.start()
+    await session.stream.recv(channel="client_exit")
+
+    # Check that it works
+    with open("multifile_calculator/calculator.py") as f:
+        calculator_output = f.readlines()
+    with open("scripts/echo.py") as f:
+        echo_output = f.readlines()
+    assert calculator_output[0].strip() == "# Hello"
+    assert echo_output[0].strip() == "# Hello"
+
+
+@pytest.mark.asyncio
 async def test_change_after_creation(
     mock_collect_user_input,
     mock_call_llm_api,


### PR DESCRIPTION
The code_file_manager uses absolute paths as keys but paths passed in may not be resolved leading to keyerrors. The cwd passed to sessions are also now resolved.

To be concrete this fixed two bugs:
* If you started mentat with `mentat --cwd mentat` (from outside the mentat dir) you could not make file edits.
* If you added a file outside the cwd such as `mentat ~/.zshrc` (assuming you're not in home) you could not edit it.