### PR TITLE
fix bug not showing empty lines when streaming

### DIFF
--- a/mentat/parsers/block_parser.py
+++ b/mentat/parsers/block_parser.py
@@ -78,7 +78,7 @@ class BlockParser(Parser):
         return any(
             to_match.value.startswith(cur_line.strip())
             for to_match in _BlockParserIndicator
-        )
+        ) and (bool(cur_line.strip()) or not cur_line.endswith("\n"))
 
     @override
     def _starts_special(self, line: str) -> bool:


### PR DESCRIPTION
Because we strip the line before checking if it's special, a new line with nothing but whitespace characters would always be a positive even after the newline character was added. Now, it only matches if it's a new line and there were non whitespace characters in the line as well.