### PR TITLE
Fix: Python client throws exception with session

### DIFF
--- a/mentat/session.py
+++ b/mentat/session.py
@@ -102,6 +102,7 @@ class Session:
         )
         self.ctx = session_context
         SESSION_CONTEXT.set(session_context)
+        self.error = None
 
         # Functions that require session_context
         check_version()
@@ -245,6 +246,7 @@ class Session:
                 # Helps us handle errors in tests
                 if is_test_environment():
                     print(error)
+                self.error = error
                 sentry_sdk.capture_exception(e)
                 self.stream.send(error, color="red")
             finally:

--- a/scripts/evaluate_samples.py
+++ b/scripts/evaluate_samples.py
@@ -104,7 +104,6 @@ async def evaluate_sample(sample, cwd: Path | str | None = None):
             raise SampleError(f"Invalid role found in message_history: {msg['role']}")
         conversation.add_message(msg_cls(role=msg["role"], content=msg["content"]))
     await python_client.call_mentat_auto_accept(sample.message_prompt)
-    await python_client.wait_for_edit_completion()
     await python_client.shutdown()
 
     # Get the diff between pre- and post-edit

--- a/tests/benchmarks/benchmark_runner.py
+++ b/tests/benchmarks/benchmark_runner.py
@@ -166,11 +166,8 @@ async def test_benchmark(retries, benchmarks):
                 )
                 client = PythonClient(cwd=codebase, config=benchmark.config)
                 await client.startup()
-                response = await client.call_mentat(prompt)
-                await client.call_mentat("y")
-                await client.wait_for_edit_completion()
-
-                await client.call_mentat("q")
+                response = await client.call_mentat_auto_accept(prompt)
+                await client.shutdown()
                 messages = client.get_conversation().literal_messages
                 cost_tracker = client.get_cost_tracker()
                 result.cost = cost_tracker.total_cost

--- a/tests/benchmarks/exercism_practice.py
+++ b/tests/benchmarks/exercism_practice.py
@@ -2,6 +2,7 @@ import asyncio
 import os
 from functools import partial
 from multiprocessing import Pool
+from pathlib import Path
 
 import pytest
 import tqdm
@@ -100,6 +101,7 @@ async def failure_analysis(exercise_runner, language):
 async def run_exercise(problem_dir, language="python", max_iterations=2):
     exercise_runner = ExerciseRunnerFactory.create(language, problem_dir)
     client = PythonClient(
+        cwd=Path("."),
         paths=exercise_runner.include_files(),
         exclude_paths=exercise_runner.exclude_files(),
         config=Config(),
@@ -129,7 +131,6 @@ async def run_exercise(problem_dir, language="python", max_iterations=2):
             else exercise_runner.get_error_message() + prompt_2
         )
         await client.call_mentat_auto_accept(message)
-        await client.wait_for_edit_completion()
 
         exercise_runner.run_test()
         iterations += 1

--- a/tests/clients/python_client_test.py
+++ b/tests/clients/python_client_test.py
@@ -1,4 +1,5 @@
 from textwrap import dedent
+from unittest.mock import MagicMock
 
 import pytest
 
@@ -28,7 +29,6 @@ async def test_editing_file_auto_accept(temp_testbed, mock_call_llm_api):
     python_client = PythonClient(cwd=temp_testbed, paths=["."])
     await python_client.startup()
     await python_client.call_mentat_auto_accept("Conversation")
-    await python_client.wait_for_edit_completion()
     with open(file_name, "r") as f:
         content = f.read()
         expected_content = "# Line 1\n# Line 2"
@@ -63,3 +63,15 @@ async def test_collects_mentat_response(temp_testbed, mock_call_llm_api):
     assert "Conversation" in response
     assert "Apply these changes? 'Y/n/i' or provide feedback." in response
     await python_client.shutdown()
+
+
+@pytest.mark.asyncio
+async def test_graceful_failure_on_session_exit(temp_testbed):
+    python_client = PythonClient()
+    await python_client.startup()
+
+    python_client.get_conversation().display_token_count = MagicMock(
+        side_effect=Exception("test")
+    )
+    with pytest.raises(Exception, match="Session failed"):
+        await python_client.call_mentat("Conversation")

--- a/tests/sampler_test.py
+++ b/tests/sampler_test.py
@@ -388,7 +388,6 @@ async def test_sampler_integration(
         5. Delete "format_examples/replacement.txt"
         6. Rename "scripts/echo1.py" to "scripts/echo2.py"
         """))
-    await python_client.wait_for_edit_completion()
 
     # Remove all included files; rely on the diff to include them
     python_client.session.ctx.code_context.include_files = {}


### PR DESCRIPTION
Currently if the session fails the python client will continue to wait for input. This change interrupts the call_mentat function when the session fails and prints out the session's exception.