### PR TITLE
Fixes #429 (ignore chunks with empty choices array)

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,8 @@ You'll need to have API access to GPT-4 to run Mentat. There are a few options t
 
 Mentat also works with the Azure OpenAI API. To use the Azure API, provide the `AZURE_OPENAI_ENDPOINT` (`https://<your-instance-name>.openai.azure.com/`) and `AZURE_OPENAI_KEY` environment variables instead of `OPENAI_API_KEY`.
 
+In addition, Mentat uses the `gpt-4-1106-preview` by default. On Azure, this model is available under a different name: `gpt-4-1106-Preview` (with a capital P). To use it, override the default model as described in [configuration.md](docs/configuration.md).
+
 > **_Important:_** Due to changes in the OpenAI Python SDK, you can no longer use `OPENAI_API_BASE` to access the Azure API with Mentat.
 
 ## Configuration

--- a/mentat/cost_tracker.py
+++ b/mentat/cost_tracker.py
@@ -77,6 +77,9 @@ class CostTracker:
         full_response = ""
         start_time = default_timer()
         async for chunk in response:
+            # On Azure OpenAI, the first chunk streamed may contain only metadata relating to content filtering.
+            if len(chunk.choices) == 0:
+                continue
             full_response += chunk.choices[0].delta.content or ""
             yield chunk
         time_elapsed = default_timer() - start_time

--- a/mentat/llm_api_handler.py
+++ b/mentat/llm_api_handler.py
@@ -80,7 +80,9 @@ def api_guard(func: Callable[..., Any]) -> Callable[..., Any]:
 
 # Ensures that each chunk will have at most one newline character
 def chunk_to_lines(chunk: ChatCompletionChunk) -> list[str]:
-    content = chunk.choices[0].delta.content
+    content = None
+    if len(chunk.choices) > 0:
+        content = chunk.choices[0].delta.content
     return ("" if content is None else content).splitlines(keepends=True)
 
 


### PR DESCRIPTION
As described in #429, `chunk.choices` is sometimes an empty array, so we should guard accordingly. This only occurs when streaming responses, so I have left other occurrences of unguarded List indexing `choices[0]` as-is.

The documentation change is not related to this particular issue, but it does pertain to Azure OpenAI in general so I decided to include it in the PR.