### PR TITLE
small fixes to benchmarks

### DIFF
--- a/tests/benchmarks/benchmark_runner.py
+++ b/tests/benchmarks/benchmark_runner.py
@@ -154,7 +154,7 @@ async def run_client(client, prompt, result, messages=None):
     await client.startup()
     conversation = client.get_conversation()
     if messages is not None:
-        for msg in messages:
+        for msg in messages[::-1]:
             msg_cls = {
                 "user": ChatCompletionUserMessageParam,
                 "assistant": ChatCompletionAssistantMessageParam,

--- a/tests/benchmarks/benchmarks/mentat/license_update.py
+++ b/tests/benchmarks/benchmarks/mentat/license_update.py
@@ -24,7 +24,7 @@ commit = "b0848711c36e0c2fe9619ebb2b77dc6d27396ff2"
 minimum_context = ["tests/license_check.py:11-22"]
 
 config = Config(
-    auto_context_tokens=True,
+    auto_context_tokens=8000,
     maximum_context=8000,
 )
 


### PR DESCRIPTION
Two small things I noticed, seemed best to give them their own PR.

Messages is currently loaded backwards into a Sample - that's an error I meant to fix in v0.1.1, maybe next week. So for now either add them in reverse or remove altogether.