### PR TITLE
Benchmark and transcript Urls changed

### DIFF
--- a/mentat/resources/templates/js/transcript.js
+++ b/mentat/resources/templates/js/transcript.js
@@ -30,7 +30,7 @@ async function uploadTranscript(page, feedback) {
         },
         body: JSON.stringify(data)
     }).then(response => {
-        return `https://abante-shared-usage-examples.s3.us-east-2.amazonaws.com/${key}`;
+        return `http://transcripts.mentat.ai/${key}`;
     })
 }
 

--- a/scripts/run_and_upload_benchmarks.sh
+++ b/scripts/run_and_upload_benchmarks.sh
@@ -13,13 +13,14 @@ pytest -s tests/benchmarks/exercism_practice.py \
     --benchmark
 
 SUMMARY=$(jq '.summary_string' benchmark_repos/exercism-javascript/results.json)
+BUCKET="benchmarks.mentat.ai"
 
 # Upload results to S3
-aws s3 cp benchmark_repos/exercism-javascript/results.html s3://abante-benchmark-results/exercism-javascript-results-${TIMESTAMP}.html
-aws s3 cp benchmark_repos/exercism-javascript/results.json s3://abante-benchmark-results-json/exercism-javascript-results-${TIMESTAMP}.json
+aws s3 cp benchmark_repos/exercism-javascript/results.html s3://${BUCKET}/exercism-javascript-results-${TIMESTAMP}.html
+aws s3 cp benchmark_repos/exercism-javascript/results.json s3://${BUCKET}/exercism-javascript-results-${TIMESTAMP}.json
 
 # Send slack notification
-JAVASCRIPT_RESULTS_URL="https://abante-benchmark-results.s3.amazonaws.com/exercism-javascript-results-${TIMESTAMP}.html"
+JAVASCRIPT_RESULTS_URL="http://${BUCKET}/exercism-javascript-results-${TIMESTAMP}.html"
 curl -X POST -H "Content-Type: application/json" -d "{\"benchmark_report\": \"${JAVASCRIPT_RESULTS_URL}\", \"summary\": ${SUMMARY}}" $SLACK_BENCHMARK_NOTIFICATION_WEBHOOK
 
 
@@ -36,11 +37,11 @@ pytest -s tests/benchmarks/exercism_practice.py \
 SUMMARY=$(jq '.summary_string' benchmark_repos/exercism-python/results.json)
 
 # Upload results to S3
-aws s3 cp benchmark_repos/exercism-python/results.html s3://abante-benchmark-results/exercism-python-results-${TIMESTAMP}.html
-aws s3 cp benchmark_repos/exercism-python/results.json s3://abante-benchmark-results-json/exercism-python-results-${TIMESTAMP}.json
+aws s3 cp benchmark_repos/exercism-python/results.html s3://${BUCKET}/exercism-python-results-${TIMESTAMP}.html
+aws s3 cp benchmark_repos/exercism-python/results.json s3://${BUCKET}/exercism-python-results-${TIMESTAMP}.json
 
 # Send slack notification
-PYTHON_RESULTS_URL="https://abante-benchmark-results.s3.amazonaws.com/exercism-python-results-${TIMESTAMP}.html"
+PYTHON_RESULTS_URL="http://${BUCKET}/exercism-python-results-${TIMESTAMP}.html"
 curl -X POST -H "Content-Type: application/json" -d "{\"benchmark_report\": \"${PYTHON_RESULTS_URL}\", \"summary\": ${SUMMARY}}" $SLACK_BENCHMARK_NOTIFICATION_WEBHOOK
 
 
@@ -51,9 +52,9 @@ pytest tests/benchmarks/benchmark_runner.py --benchmark -s --retries 2
 SUMMARY=$(jq '.summary_string' results.json)
 
 # Upload results to S3
-aws s3 cp results.html s3://abante-benchmark-results/real-world-benchmark-results-${TIMESTAMP}.html
-aws s3 cp results.json s3://abante-benchmark-results-json/real-world-benchmark-results-${TIMESTAMP}.json
+aws s3 cp results.html s3://${BUCKET}/real-world-benchmark-results-${TIMESTAMP}.html
+aws s3 cp results.json s3://${BUCKET}/real-world-benchmark-results-${TIMESTAMP}.json
 
 # Send slack notification
-REAL_WORLD_RESULTS_URL="https://abante-benchmark-results.s3.amazonaws.com/real-world-benchmark-results-${TIMESTAMP}.html"
+REAL_WORLD_RESULTS_URL="http://${BUCKET}/real-world-benchmark-results-${TIMESTAMP}.html"
 curl -X POST -H "Content-Type: application/json" -d "{\"benchmark_report\": \"${REAL_WORLD_RESULTS_URL}\", \"summary\": ${SUMMARY}}" $SLACK_BENCHMARK_NOTIFICATION_WEBHOOK


### PR DESCRIPTION
benchmarks.mentat.ai and transcripts.mentat.ai now point to s3 buckets. This change gives users the pretty URLs for transcripts and benchmarks.

The lambda currently puts transcripts in both buckets so the functionality will continue to work for old versions.

## Pull Request Checklist
- [x] Documentation has been updated, or this change doesn't require that
