### PR TITLE
add full file_edits_to_llm_message + tests

### DIFF
--- a/mentat/conversation.py
+++ b/mentat/conversation.py
@@ -237,7 +237,7 @@ class Conversation:
 
         # Get current code message
         loading_multiplier = 1.0 if config.auto_context_tokens > 0 else 0.0
-        prompt = messages_snapshot[-1]["content"]
+        prompt = messages_snapshot[-1].get("content")
         if isinstance(prompt, list):
             text_prompts = [
                 p.get("text", "") for p in prompt if p.get("type") == "text"

--- a/mentat/parsers/git_parser.py
+++ b/mentat/parsers/git_parser.py
@@ -14,8 +14,8 @@ for the LLM. We implement only those methods/properties which are necessary for 
 Things to be aware of:
 1. git diffs include SHA-1 hashes, which link the diff to a known record in the git repo. When
     we generate diffs from scratch, we won't have these, so the diff can't be reverse-applied via
-    e.g. `git apply myfile.diff`. The SHA-1 hashes should also be removed e.g. when comparing 
-    outputs in tests as they are not expected to match.
+    `git apply myfile.diff`. The SHA-1 hashes should also be removed when comparing outputs in 
+    tests as they are not expected to match.
 
 2. git diffs include removed and to-be-modified lines, prefixed with a '-'. These are drawn from
     FileEdit.previous_file_lines field. When calling GitParser.file_edits_to_llm_message, 
@@ -30,85 +30,6 @@ b = number of original lines changed, omitted if = 1
 c = edited starting line number
 d = number of edited lines in the change, ommitted if = 1
 """
-
-
-def file_edit_to_git_diff(file_edit: FileEdit) -> str:
-    """Converts a FileEdit object into a git diff string."""
-    session_context = SESSION_CONTEXT.get()
-    cwd = session_context.cwd
-
-    diff_lines: list[str] = []
-    file_path = Path(file_edit.file_path).relative_to(session_context.cwd)
-    file_path_str = str(file_path)
-
-    if file_edit.is_deletion:
-        assert file_edit.previous_file_lines is not None, "Missing previous lines"
-        diff_lines.append(f"diff --git a/{file_path_str} b/{file_path_str}")
-        diff_lines.append("deleted file mode 100644")
-        diff_lines.append("index fffffff..0000000")
-        diff_lines.append(f"--- a/{file_path_str}")
-        diff_lines.append("+++ /dev/null")
-        diff_lines.append(f"@@ -1,{len(file_edit.previous_file_lines) - 1} +0,0 @@")
-        for line in file_edit.previous_file_lines:
-            diff_lines.append(f"-{line}")
-        if diff_lines[-1] == "-":
-            diff_lines = diff_lines[:-1]
-        return "\n".join(diff_lines)
-
-    if file_edit.is_creation:
-        diff_lines.append(f"diff --git a/{file_path_str} b/{file_path_str}")
-        diff_lines.append("new file mode 100644")
-        diff_lines.append("index 0000000..fffffff")
-        diff_lines.append("--- /dev/null")
-        diff_lines.append(f"+++ b/{file_path_str}")
-    elif file_edit.rename_file_path:
-        new_file_path = file_edit.rename_file_path.relative_to(cwd)
-        new_file_path_str = str(new_file_path)
-        diff_lines.append(f"diff --git a/{file_path_str} b/{new_file_path_str}")
-        diff_lines.append("similarity index 100%")
-        diff_lines.append(f"rename from {file_path_str}")
-        diff_lines.append(f"rename to {new_file_path_str}")
-    else:
-        diff_lines.append(f"diff --git a/{file_path_str} b/{file_path_str}")
-        diff_lines.append("index fffffff..fffffff 100644")
-        diff_lines.append(f"--- a/{file_path_str}")
-        diff_lines.append(f"+++ b/{file_path_str}")
-
-    sorted_replacements = sorted(file_edit.replacements, key=lambda r: r.starting_line)
-    net_change_in_lines: int = 0
-    for replacement in sorted_replacements:
-        if file_edit.is_creation:
-            a = 0
-            b = 0
-        else:
-            n_changed_lines = replacement.ending_line - replacement.starting_line
-            a = replacement.starting_line + (1 if n_changed_lines > 0 else 0)
-            b = n_changed_lines
-        n_inserted_lines = len(replacement.new_lines)
-        c = (
-            replacement.starting_line
-            + 1  # Git uses one-based indiexing
-            - (1 if n_inserted_lines == 0 else 0)
-            + net_change_in_lines
-        )
-        d = n_inserted_lines
-        hunk_header = (
-            f"@@ -{a}"
-            + (" " if b == 1 else f",{b} ")
-            + f"+{c}"
-            + (" @@" if d == 1 else f",{d} @@")
-        )
-        net_change_in_lines += d - b
-        diff_lines.append(hunk_header)
-
-        if not file_edit.is_creation:
-            assert file_edit.previous_file_lines is not None, "Missing previous lines"
-            for line in range(a, a + b):
-                diff_lines.append(f"-{file_edit.previous_file_lines[line - 1]}")
-        for line in replacement.new_lines:
-            diff_lines.append(f"+{line}")
-
-    return "\n".join(diff_lines)
 
 
 class GitParser:
@@ -244,10 +165,86 @@ class GitParser:
             file_edits.append(file_edit)
 
         return ParsedLLMResponse(git_diff, commit_message, file_edits)
+    
+    def file_edit_to_git_diff(self, file_edit: FileEdit) -> str:
+        """Converts a FileEdit object into a git diff string."""
+        session_context = SESSION_CONTEXT.get()
+        cwd = session_context.cwd
+
+        diff_lines: list[str] = []
+        file_path_str = Path(file_edit.file_path).relative_to(session_context.cwd).as_posix()
+
+        if file_edit.is_deletion:
+            assert file_edit.previous_file_lines is not None, "Missing previous lines"
+            diff_lines.append(f"diff --git a/{file_path_str} b/{file_path_str}")
+            diff_lines.append("deleted file mode 100644")
+            diff_lines.append("index fffffff..0000000")
+            diff_lines.append(f"--- a/{file_path_str}")
+            diff_lines.append("+++ /dev/null")
+            diff_lines.append(f"@@ -1,{len(file_edit.previous_file_lines) - 1} +0,0 @@")
+            for line in file_edit.previous_file_lines:
+                diff_lines.append(f"-{line}")
+            if diff_lines[-1] == "-":
+                diff_lines = diff_lines[:-1]
+            return "\n".join(diff_lines)
+
+        if file_edit.is_creation:
+            diff_lines.append(f"diff --git a/{file_path_str} b/{file_path_str}")
+            diff_lines.append("new file mode 100644")
+            diff_lines.append("index 0000000..fffffff")
+            diff_lines.append("--- /dev/null")
+            diff_lines.append(f"+++ b/{file_path_str}")
+        elif file_edit.rename_file_path:
+            new_file_path_str = file_edit.rename_file_path.relative_to(cwd).as_posix()
+            diff_lines.append(f"diff --git a/{file_path_str} b/{new_file_path_str}")
+            diff_lines.append("similarity index 100%")
+            diff_lines.append(f"rename from {file_path_str}")
+            diff_lines.append(f"rename to {new_file_path_str}")
+        else:
+            diff_lines.append(f"diff --git a/{file_path_str} b/{file_path_str}")
+            diff_lines.append("index fffffff..fffffff 100644")
+            diff_lines.append(f"--- a/{file_path_str}")
+            diff_lines.append(f"+++ b/{file_path_str}")
+
+        sorted_replacements = sorted(file_edit.replacements, key=lambda r: r.starting_line)
+        net_change_in_lines: int = 0
+        for replacement in sorted_replacements:
+            if file_edit.is_creation:
+                a = 0
+                b = 0
+            else:
+                n_changed_lines = replacement.ending_line - replacement.starting_line
+                a = replacement.starting_line + (1 if n_changed_lines > 0 else 0)
+                b = n_changed_lines
+            n_inserted_lines = len(replacement.new_lines)
+            c = (
+                replacement.starting_line
+                + 1  # Git uses one-based indiexing
+                - (1 if n_inserted_lines == 0 else 0)
+                + net_change_in_lines
+            )
+            d = n_inserted_lines
+            hunk_header = (
+                f"@@ -{a}"
+                + (" " if b == 1 else f",{b} ")
+                + f"+{c}"
+                + (" @@" if d == 1 else f",{d} @@")
+            )
+            net_change_in_lines += d - b
+            diff_lines.append(hunk_header)
+
+            if not file_edit.is_creation:
+                assert file_edit.previous_file_lines is not None, "Missing previous lines"
+                for line in range(a, a + b):
+                    diff_lines.append(f"-{file_edit.previous_file_lines[line - 1]}")
+            for line in replacement.new_lines:
+                diff_lines.append(f"+{line}")
+
+        return "\n".join(diff_lines)
 
     def file_edits_to_llm_message(self, parsedLLMResponse: ParsedLLMResponse) -> str:
         ans = parsedLLMResponse.conversation.strip() + "\n\n"
         for file_edit in parsedLLMResponse.file_edits:
-            ans += file_edit_to_git_diff(file_edit) + "\n"
+            ans += self.file_edit_to_git_diff(file_edit) + "\n"
 
         return ans

--- a/mentat/parsers/git_parser.py
+++ b/mentat/parsers/git_parser.py
@@ -165,14 +165,16 @@ class GitParser:
             file_edits.append(file_edit)
 
         return ParsedLLMResponse(git_diff, commit_message, file_edits)
-    
+
     def file_edit_to_git_diff(self, file_edit: FileEdit) -> str:
         """Converts a FileEdit object into a git diff string."""
         session_context = SESSION_CONTEXT.get()
         cwd = session_context.cwd
 
         diff_lines: list[str] = []
-        file_path_str = Path(file_edit.file_path).relative_to(session_context.cwd).as_posix()
+        file_path_str = (
+            Path(file_edit.file_path).relative_to(session_context.cwd).as_posix()
+        )
 
         if file_edit.is_deletion:
             assert file_edit.previous_file_lines is not None, "Missing previous lines"
@@ -206,7 +208,9 @@ class GitParser:
             diff_lines.append(f"--- a/{file_path_str}")
             diff_lines.append(f"+++ b/{file_path_str}")
 
-        sorted_replacements = sorted(file_edit.replacements, key=lambda r: r.starting_line)
+        sorted_replacements = sorted(
+            file_edit.replacements, key=lambda r: r.starting_line
+        )
         net_change_in_lines: int = 0
         for replacement in sorted_replacements:
             if file_edit.is_creation:
@@ -234,7 +238,9 @@ class GitParser:
             diff_lines.append(hunk_header)
 
             if not file_edit.is_creation:
-                assert file_edit.previous_file_lines is not None, "Missing previous lines"
+                assert (
+                    file_edit.previous_file_lines is not None
+                ), "Missing previous lines"
                 for line in range(a, a + b):
                     diff_lines.append(f"-{file_edit.previous_file_lines[line - 1]}")
             for line in replacement.new_lines:

--- a/mentat/revisor/revisor.py
+++ b/mentat/revisor/revisor.py
@@ -99,7 +99,7 @@ async def revise_edit(file_edit: FileEdit):
         "diff --git a/file b/file\nindex 0000000..0000000\n--- a/file\n+++"
         f" b/file\n{message}"
     )
-    parsed_response = GitParser().parse_string(post_diff)
+    parsed_response = GitParser().parse_llm_response(post_diff)
 
     # Only modify the replacements of the current file edit
     # (the new file edit doesn't know about file creation or renaming)

--- a/mentat/sampler/sampler.py
+++ b/mentat/sampler/sampler.py
@@ -171,7 +171,7 @@ class Sampler:
             context.update(_rp(f) for f in feature_refs)
         # Undo adds/removes/renames to match pre-diff_edit state
         if diff_edit:
-            file_edits = GitParser().parse_string(diff_edit).file_edits
+            file_edits = GitParser().parse_llm_response(diff_edit).file_edits
             for file_edit in file_edits:
                 file_path = _rp(file_edit.file_path)
                 rename_path = (

--- a/scripts/git_log_to_transcripts.py
+++ b/scripts/git_log_to_transcripts.py
@@ -130,7 +130,7 @@ async def translate_commits_to_transcripts(repo, count=10):
                 print("Skipping because too long")
                 continue
 
-            parsedLLMResponse = GitParser().parse_string(shown)
+            parsedLLMResponse = GitParser().parse_llm_response(shown)
 
             code_context.set_paths(bound_files(parsedLLMResponse.file_edits), [])
             code_message = await code_context.get_code_message("", 0)

--- a/scripts/sampler/finetune.py
+++ b/scripts/sampler/finetune.py
@@ -45,7 +45,7 @@ async def generate_finetune(
     conversation.append({"role": "user", "content": sample.message_prompt})
     message_example = sample.message_edit or ""
     if sample.diff_edit:  # Convert any diff_edit to block format for answer
-        parsed_llm_response = GitParser().parse_string(sample.diff_edit)
+        parsed_llm_response = GitParser().parse_llm_response(sample.diff_edit)
         message_example += ctx.config.parser.file_edits_to_llm_message(
             parsed_llm_response
         )

--- a/tests/parser_tests/git_parser_test.py
+++ b/tests/parser_tests/git_parser_test.py
@@ -1,0 +1,197 @@
+import os
+import re
+from textwrap import dedent
+
+import pytest
+from git import Repo
+
+from mentat.parsers.file_edit import FileEdit, Replacement
+from mentat.parsers.git_parser import GitParser, file_edit_to_git_diff
+from mentat.parsers.parser import ParsedLLMResponse
+from mentat.utils import convert_string_to_asynciter
+
+
+def clean_diff(diff):
+    """
+    NOTE: Git diffs include a SHA-1 hash, which links the diff to a known record
+    in the git repo. We won't have that, so diffs generated with this function cannot be
+    applied via `git apply myfile.diff`.
+    """
+    diff = re.sub(r"\bindex \b[0-9a-f]{5,40}\b.*", "", diff)  # Remove hexshas
+    diff = re.sub(r"(@@ [^@]* @@).*", r"\1", diff)  # Remove context from hunk_headers
+    return diff
+
+
+@pytest.fixture
+def create_file_edit(temp_testbed):
+    return FileEdit(
+        file_path=temp_testbed / "create.txt",
+        replacements=[
+            Replacement(
+                starting_line=0,
+                ending_line=0,
+                new_lines=["# I created this file", "# And it has two lines"],
+            )
+        ],
+        is_creation=True,
+    )
+
+
+@pytest.fixture
+def delete_file_edit(temp_testbed, mock_session_context):
+    file_to_delete = temp_testbed / "format_examples" / "replacement.txt"
+    previous_file_lines = mock_session_context.code_file_manager.read_file(
+        file_to_delete
+    )
+    return FileEdit(
+        file_path=file_to_delete,
+        replacements=[],
+        is_deletion=True,
+        previous_file_lines=previous_file_lines,
+    )
+
+
+@pytest.fixture
+def rename_file_edit(temp_testbed, mock_session_context):
+    file_to_rename = temp_testbed / "scripts" / "echo.py"
+    cfm = mock_session_context.code_file_manager
+    rename_to = temp_testbed / "scripts" / "echo2.py"
+    return FileEdit(
+        file_path=file_to_rename,
+        rename_file_path=rename_to,
+        previous_file_lines=cfm.read_file(file_to_rename),
+    )
+
+
+@pytest.fixture
+def modify_file_edit(temp_testbed, mock_session_context):
+    file_to_modify = temp_testbed / "multifile_calculator" / "operations.py"
+    previous_file_lines = mock_session_context.code_file_manager.read_file(
+        file_to_modify
+    )
+    return FileEdit(
+        file_path=file_to_modify,
+        replacements=[
+            Replacement(starting_line=0, ending_line=1, new_lines=[]),  # Remove a line
+            Replacement(
+                starting_line=4,
+                ending_line=5,
+                new_lines=["def multiply_numbers(a, b): # I modified this line"],
+            ),
+            Replacement(
+                starting_line=14, ending_line=14, new_lines=["# I added this line"]
+            ),
+        ],
+        previous_file_lines=previous_file_lines,
+    )
+
+
+def test_creation_file_edit_to_git_diff(temp_testbed, create_file_edit):
+    repo = Repo(temp_testbed)
+
+    add_file_diff = file_edit_to_git_diff(create_file_edit)
+
+    with open(temp_testbed / "create.txt", "w") as f:
+        f.write("# I created this file\n# And it has two lines\n")
+    repo.git.add(["--all"])
+    expected_diff = repo.git.diff(["--staged"], unified=0)
+
+    assert clean_diff(add_file_diff) == clean_diff(expected_diff)
+    # TODO: Test with one or multiple lines
+
+
+def test_deletion_file_edit_to_git_diff(temp_testbed, delete_file_edit):
+    repo = Repo(temp_testbed)
+
+    delete_file_diff = file_edit_to_git_diff(delete_file_edit)
+
+    file_to_delete = delete_file_edit.file_path
+    file_to_delete.unlink()
+    repo.git.add(["--all"])
+    expected_diff = repo.git.diff(["--staged"], unified=0)
+
+    assert not file_to_delete.exists()
+    assert clean_diff(expected_diff) == clean_diff(delete_file_diff)
+
+
+def test_rename_file_edit_to_git_diff(temp_testbed, rename_file_edit):
+    repo = Repo(temp_testbed)
+
+    rename_file_diff = file_edit_to_git_diff(rename_file_edit)
+
+    os.rename(rename_file_edit.file_path, rename_file_edit.rename_file_path)
+    repo.git.add(["--all"])
+    expected_diff = repo.git.diff(["--staged"], unified=0)
+
+    assert clean_diff(rename_file_diff) == clean_diff(expected_diff)
+    # TODO: Test with and without edits
+
+
+def test_modify_file_edit_to_git_diff(temp_testbed, modify_file_edit):
+    repo = Repo(temp_testbed)
+
+    modify_file_diff = file_edit_to_git_diff(modify_file_edit)
+
+    with open(modify_file_edit.file_path, "w") as f:
+        f.write(dedent("""\
+            return a + b
+
+
+        def multiply_numbers(a, b): # I modified this line
+            return a * b
+
+
+        def subtract_numbers(a, b):
+            return a - b
+
+
+        def divide_numbers(a, b):
+            return a / b
+        # I added this line
+        """))
+    repo.git.add(["--all"])
+    expected_diff = repo.git.diff(["--staged"], unified=0)
+
+    assert clean_diff(modify_file_diff) == clean_diff(expected_diff)
+
+
+@pytest.mark.asyncio
+async def test_git_parser_inverse(
+    temp_testbed, create_file_edit, delete_file_edit, rename_file_edit, modify_file_edit
+):
+    """
+    This is mostly a duplicate of inverse.py, but the git_parser needs the removed/previous
+    lines so I use actual files instead.
+    """
+    parsedLLMResponse = ParsedLLMResponse(
+        full_response="",
+        conversation=dedent("""\
+            Conversation
+            with two lines
+        """),
+        file_edits=[
+            create_file_edit,
+            delete_file_edit,
+            rename_file_edit,
+            modify_file_edit,
+        ],
+    )
+
+    parser = GitParser()
+
+    inverse = parser.file_edits_to_llm_message(parsedLLMResponse)
+    generator = convert_string_to_asynciter(inverse, 10)
+    back_once = await parser.stream_and_parse_llm_response(generator)
+    inverse2 = parser.file_edits_to_llm_message(back_once)
+    generator2 = convert_string_to_asynciter(inverse2, 10)
+    back_twice = await parser.stream_and_parse_llm_response(generator2)
+
+    # The full_response is originally blank for compatibility with all formats. So we invert twice.
+    for pre_edit, edit_once in zip(parsedLLMResponse.file_edits, back_once.file_edits):
+        if pre_edit.is_creation:
+            continue
+        assert pre_edit == edit_once
+    assert parsedLLMResponse.file_edits == back_once.file_edits
+    assert back_once == back_twice
+    # Verify the inverse uses relative paths
+    assert "testbed" not in back_once.full_response

--- a/tests/sampler_test.py
+++ b/tests/sampler_test.py
@@ -196,7 +196,7 @@ test_sample = {
 
 @pytest.mark.asyncio
 async def test_sample_eval(mock_call_llm_api):
-    parsedLLMResponse = GitParser().parse_string(test_sample["diff_edit"])
+    parsedLLMResponse = GitParser().parse_llm_response(test_sample["diff_edit"])
     edit_message = BlockParser().file_edits_to_llm_message(parsedLLMResponse)
     mock_call_llm_api.set_streamed_values([dedent(f"""\
         I will add a new helper function called `sha1` to the `mentat/utils.py` file.
@@ -306,7 +306,7 @@ def get_updates_as_parsed_llm_message(cwd):
     # Make diff_edit edits
     make_all_update_types(cwd, 2)
     diff_edit = get_git_diff("HEAD", cwd)
-    parsedLLMResponse = GitParser().parse_string(diff_edit)
+    parsedLLMResponse = GitParser().parse_llm_response(diff_edit)
     # Reset hard and remove uncommitted files
     repo.git.reset("--hard")
     repo.git.clean("-fd")


### PR DESCRIPTION
This adds the missing `GitParser.file_edits_to_llm_message` method, which we'll use to convert file edits from your conversation history into git diffs for Sampler v.0.2.0.

## Pull Request Checklist
- [ ] Documentation has been updated, or this change doesn't require that
