### PR TITLE
Benchmark_repos specified with a relative path

### DIFF
--- a/benchmarks/benchmark_runner.py
+++ b/benchmarks/benchmark_runner.py
@@ -286,7 +286,6 @@ async def run_benchmarks(retries, benchmarks):
             results.extend(await evaluate_sample(path))
 
     summary = BenchmarkResultSummary(results)
-    os.chdir("../..")
     with open("results.json", "w") as f:
         f.write(summary.to_json())
     summary.render_results()

--- a/mentat/sampler/utils.py
+++ b/mentat/sampler/utils.py
@@ -9,7 +9,7 @@ from mentat.errors import SampleError
 from mentat.git_handler import get_non_gitignored_files
 from mentat.utils import is_file_text_encoded
 
-CLONE_TO_DIR = Path(__file__).parent.parent.parent / "benchmark_repos"
+CLONE_TO_DIR = Path("benchmark_repos")
 
 
 def clone_repo(


### PR DESCRIPTION
The motivation for this PR is a fix for the benchmark github action. Now that the benchmarks are in a different package the aren't importing mentat code from where they did previously in the file system. This change should have no effect for people calling clone_repo from the mentat root dir.
I think in general it makes sense that the caller of setup_repo would expect the repo to be places in benchmark_repos of their cwd not relative to some script that they may not know about and may be in a strange unpredictable place depending on how mentat is installed.

## Pull Request Checklist
- [x] Documentation has been updated, or this change doesn't require that
