### PR TITLE
Active diff snapshot not automatically run

### DIFF
--- a/mentat/config.py
+++ b/mentat/config.py
@@ -109,6 +109,16 @@ class Config:
         },
         converter=converters.optional(converters.to_bool),
     )
+    auto_save_snapshot: bool = attr.field(
+        default=False,
+        metadata={
+            "description": (
+                "Automatically saves a git diff snapshot for the sampler on startup."
+            ),
+            "auto_completions": bool_autocomplete,
+        },
+        converter=converters.optional(converters.to_bool),
+    )
 
     # Context specific settings
     file_exclude_glob_list: list[str] = attr.field(

--- a/mentat/session.py
+++ b/mentat/session.py
@@ -117,7 +117,8 @@ class Session:
         ):
             for file in code_context.diff_context.diff_files():
                 code_context.include(file)
-        sampler.set_active_diff()
+        if config.auto_save_snapshot:
+            sampler.set_active_diff()
 
     def _create_task(self, coro: Coroutine[None, None, Any]):
         """Utility method for running a Task in the background"""


### PR DESCRIPTION
It's not very safe to be messing with git at startup. There are a lot of edge cases. Most users won't use the sampler at all and even with this change the sampler will still work well assuming the changes being made aren't related to the active diff.

## Pull Request Checklist
- [x] Documentation has been updated, or this change doesn't require that
