### PR TITLE
Python client default mentat export

### DIFF
--- a/benchmarks/edit_rubric_benchmark.py
+++ b/benchmarks/edit_rubric_benchmark.py
@@ -11,7 +11,7 @@ from git import Repo
 from openai import OpenAI
 
 from benchmarks.arg_parser import common_benchmark_parser
-from mentat.python_client.client import PythonClient
+from mentat import Mentat
 from mentat.sampler.utils import clone_repo
 
 
@@ -103,7 +103,7 @@ async def test_edit_quality(
         start_commit = repo.commit()
         repo.git.checkout(test["commit"] + "^1")
 
-        client = PythonClient(
+        client = Mentat(
             paths=test["expected_features"],
         )
 

--- a/benchmarks/exercism_practice.py
+++ b/benchmarks/exercism_practice.py
@@ -12,8 +12,8 @@ from benchmarks.arg_parser import common_benchmark_parser
 from benchmarks.benchmark_result import BenchmarkResult
 from benchmarks.benchmark_result_summary import BenchmarkResultSummary
 from benchmarks.exercise_runners.exercise_runner_factory import ExerciseRunnerFactory
+from mentat import Mentat
 from mentat.config import Config
-from mentat.python_client.client import PythonClient
 from mentat.sampler.utils import clone_repo
 from mentat.session_context import SESSION_CONTEXT
 
@@ -81,7 +81,7 @@ async def failure_analysis(exercise_runner, language):
 
 async def run_exercise(problem_dir, language="python", max_iterations=2):
     exercise_runner = ExerciseRunnerFactory.create(language, problem_dir)
-    client = PythonClient(
+    client = Mentat(
         cwd=Path("."),
         paths=exercise_runner.include_files(),
         exclude_paths=exercise_runner.exclude_files(),

--- a/benchmarks/run_sample.py
+++ b/benchmarks/run_sample.py
@@ -1,10 +1,10 @@
 from pathlib import Path
 from typing import Any
 
+from mentat import Mentat
 from mentat.errors import SampleError
 from mentat.git_handler import get_git_diff
 from mentat.parsers.git_parser import GitParser
-from mentat.python_client.client import PythonClient
 from mentat.sampler.sample import Sample
 from mentat.sampler.utils import get_active_snapshot_commit, setup_repo
 from mentat.session_context import SESSION_CONTEXT
@@ -30,8 +30,8 @@ async def run_sample(sample: Sample, cwd: Path | str | None = None) -> dict[str,
     paths = list[Path]()
     for a in sample.context:
         paths.append(Path(a))
-    python_client = PythonClient(cwd=cwd, paths=paths)
-    await python_client.startup()
+    mentat = Mentat(cwd=cwd, paths=paths)
+    await mentat.startup()
     session_context = SESSION_CONTEXT.get()
     conversation = session_context.conversation
     cost_tracker = session_context.cost_tracker
@@ -49,8 +49,8 @@ async def run_sample(sample: Sample, cwd: Path | str | None = None) -> dict[str,
             conversation.add_model_message(content, [], parsed_llm_response)
         else:
             raise SampleError(f"Invalid role found in message_history: {msg['role']}")
-    await python_client.call_mentat_auto_accept(sample.message_prompt)
-    await python_client.shutdown()
+    await mentat.call_mentat_auto_accept(sample.message_prompt)
+    await mentat.shutdown()
 
     # Get the diff between pre- and post-edit
     transcript_messages = conversation.literal_messages.copy()

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -11,6 +11,7 @@ Welcome to Mentat's documentation!
    :caption: Contents:
 
    user/guides
+   sdk/index
    developer/modules
 
 

--- a/docs/source/sdk/index.rst
+++ b/docs/source/sdk/index.rst
@@ -1,0 +1,10 @@
+Python SDK Guide
+================
+
+You can import Mentat in your python programs and use it programmatically. For an example see the `usage` section. For full specs of the python module see the `module` section.
+
+.. toctree::
+   :maxdepth: 1
+
+   usage
+   module

--- a/docs/source/sdk/module.rst
+++ b/docs/source/sdk/module.rst
@@ -1,0 +1,10 @@
+Python Client
+=============
+
+mentat.python\_client.client module
+-----------------------------------
+
+.. automodule:: mentat.python_client.client
+   :members:
+   :undoc-members:
+

--- a/docs/source/sdk/usage.rst
+++ b/docs/source/sdk/usage.rst
@@ -1,0 +1,15 @@
+Python SDK Usage
+================
+
+The Python SDK allows you to use mentat in your python programs. If you have mentat installed you can use it like this:
+
+.. code-block:: python
+
+   from mentat import Mentat
+   client = Mentat(paths=['README.md'])
+
+   client.startup()
+   client.call_mentat_auto_accept("Please fix the typos in the Readme.")
+   client.shutdown()
+
+All the same options are available as in the command line interface. You can use commands and change configuration by passing in a mentat.Config object.

--- a/mentat/__init__.py
+++ b/mentat/__init__.py
@@ -1,1 +1,1 @@
-from mentat.python_client.client import PythonClient as Mentat  # noqa: F401
+from mentat.python_client.client import PythonClient as Mentat  # noqa: F401 # pyright: ignore

--- a/mentat/__init__.py
+++ b/mentat/__init__.py
@@ -1,1 +1,3 @@
-from mentat.python_client.client import PythonClient as Mentat  # noqa: F401 # pyright: ignore
+from mentat.python_client.client import (
+    PythonClient as Mentat,
+)  # noqa: F401 # pyright: ignore

--- a/mentat/__init__.py
+++ b/mentat/__init__.py
@@ -1,4 +1,1 @@
-# Make sure to bump this on Release x.y.z PR's!
-__version__ = "1.0.9"
-
 from mentat.python_client.client import PythonClient as Mentat  # noqa: F401

--- a/mentat/__init__.py
+++ b/mentat/__init__.py
@@ -1,3 +1,3 @@
 from mentat.python_client.client import (
-    PythonClient as Mentat,
-)  # noqa: F401 # pyright: ignore
+    PythonClient as Mentat,  # noqa: F401 # pyright: ignore
+)

--- a/mentat/__init__.py
+++ b/mentat/__init__.py
@@ -1,2 +1,4 @@
 # Make sure to bump this on Release x.y.z PR's!
 __version__ = "1.0.9"
+
+from mentat.python_client.client import PythonClient as Mentat

--- a/mentat/__init__.py
+++ b/mentat/__init__.py
@@ -1,3 +1,3 @@
-from mentat.python_client.client import (
+from mentat.python_client.client import (  # isort: skip
     PythonClient as Mentat,  # noqa: F401 # pyright: ignore
 )

--- a/mentat/__init__.py
+++ b/mentat/__init__.py
@@ -1,4 +1,4 @@
 # Make sure to bump this on Release x.y.z PR's!
 __version__ = "1.0.9"
 
-from mentat.python_client.client import PythonClient as Mentat
+from mentat.python_client.client import PythonClient as Mentat  # noqa: F401

--- a/mentat/python_client/client.py
+++ b/mentat/python_client/client.py
@@ -11,6 +11,8 @@ from mentat.session_stream import StreamMessageSource
 
 
 class PythonClient:
+    """A client for interacting with Mentat in python."""
+
     def __init__(
         self,
         cwd: Path = Path.cwd(),
@@ -21,6 +23,20 @@ class PythonClient:
         pr_diff: str | None = None,
         config: Config = Config(),
     ):
+        """
+        Initializes the PythonClient with configuration for interacting with Mentat.
+
+        You must call `startup` to begin the client and `shutdown` to end it.
+
+        Parameters:
+        - cwd (Path): The current working directory for the client.
+        - paths (List[Path]): A list of paths to include in the analysis.
+        - exclude_paths (List[Path]): A list of paths to exclude from the analysis.
+        - ignore_paths (List[Path]): A list of paths to ignore for the purpose of analysis.
+        - diff (str | None): A treeish diff that mentat will be aware of when making changes.
+        - pr_diff (str | None): Like diff but it compares to the common ancester.
+        - config (Config): Configuration settings for the client.
+        """
         self.cwd = cwd.expanduser().resolve()
         self.paths = paths
         self.exclude_paths = exclude_paths
@@ -48,6 +64,10 @@ class PythonClient:
         return temp
 
     async def call_mentat(self, message: str):
+        """Call Mentat with a message and return the response.
+
+        Behaves the same as talking to mentat as an application so you can use commands.
+        """
         self._call_mentat_task = asyncio.create_task(self._call_mentat(message))
         try:
             return await self._call_mentat_task
@@ -55,9 +75,11 @@ class PythonClient:
             print(self.session.error)
             raise MentatError("Session failed")
 
-    async def call_mentat_auto_accept(self, message: str):
-        await self.call_mentat(message)
+    async def call_mentat_auto_accept(self, message: str) -> str:
+        """Call Mentat with a message and then accept the edits."""
+        response = await self.call_mentat(message)
         await self.call_mentat("y")
+        return response
 
     async def wait_for_edit_completion(self):
         await self.session.stream.recv(channel="edits_complete")
@@ -74,6 +96,7 @@ class PythonClient:
         await self._stop()
 
     async def startup(self):
+        """Starts up the client, establishing a session and beginning to listen for messages and exit signals."""
         self.session = Session(
             self.cwd,
             self.paths,
@@ -88,6 +111,7 @@ class PythonClient:
         self.exit_task: Task[None] = asyncio.create_task(self._listen_for_client_exit())
 
     async def shutdown(self):
+        """Initiates shutdown of the client, ensuring all tasks are cancelled and the session is properly closed."""
         """Sends the stop signal to the session and returns when client is fully shutdown."""
         self.session.stream.send(None, channel="session_exit")
         await self.stopped.wait()
@@ -100,7 +124,9 @@ class PythonClient:
         self.stopped.set()
 
     def get_conversation(self):
+        """Returns the current conversation context from the session."""
         return self.session.ctx.conversation
 
     def get_cost_tracker(self):
+        """Returns the cost tracker from the session context."""
         return self.session.ctx.cost_tracker

--- a/mentat/python_client/client.py
+++ b/mentat/python_client/client.py
@@ -111,8 +111,9 @@ class PythonClient:
         self.exit_task: Task[None] = asyncio.create_task(self._listen_for_client_exit())
 
     async def shutdown(self):
-        """Initiates shutdown of the client, ensuring all tasks are cancelled and the session is properly closed."""
-        """Sends the stop signal to the session and returns when client is fully shutdown."""
+        """Initiates shutdown of the client, ensuring all tasks are cancelled and the session is properly closed.
+        Sends the stop signal to the session and returns when client is fully shutdown.
+        """
         self.session.stream.send(None, channel="session_exit")
         await self.stopped.wait()
 

--- a/mentat/sentry.py
+++ b/mentat/sentry.py
@@ -2,9 +2,9 @@ import os
 import platform
 from uuid import UUID, uuid4
 
+import pkg_resources
 import sentry_sdk
 
-from mentat import __version__
 from mentat.app_conf import IS_DEV
 from mentat.utils import mentat_dir_path
 
@@ -41,7 +41,8 @@ def sentry_init():
         enable_tracing=True,
         traces_sample_rate=1.0,
     )
-    sentry_sdk.set_tag("version", __version__)
+    version = pkg_resources.require("mentat")[0].version
+    sentry_sdk.set_tag("version", version)
     sentry_sdk.set_user({"id": _get_user()})
     uname = platform.uname()
     sentry_sdk.set_context(

--- a/mentat/utils.py
+++ b/mentat/utils.py
@@ -9,12 +9,12 @@ from pathlib import Path
 from typing import TYPE_CHECKING, AsyncIterator, List, Literal, Optional, Union
 
 import packaging.version
+import pkg_resources
 import requests
 from jinja2 import Environment, PackageLoader, select_autoescape
 from openai.types.chat import ChatCompletionChunk
 from openai.types.chat.chat_completion_chunk import Choice, ChoiceDelta
 
-from mentat import __version__
 from mentat.session_context import SESSION_CONTEXT
 
 if TYPE_CHECKING:
@@ -102,7 +102,7 @@ def check_version():
         response = requests.get("https://pypi.org/pypi/mentat/json")
         data = response.json()
         latest_version = data["info"]["version"]
-        current_version = __version__
+        current_version = pkg_resources.require("mentat")[0].version
 
         if packaging.version.parse(current_version) < packaging.version.parse(
             latest_version

--- a/setup.py
+++ b/setup.py
@@ -4,8 +4,6 @@ from pathlib import Path
 import pkg_resources
 from setuptools import find_packages, setup
 
-from mentat import __version__
-
 readme_path = os.path.join(Path(__file__).parent, "README.md")
 with open(readme_path, "r", encoding="utf-8") as f:
     long_description = f.read()
@@ -13,7 +11,7 @@ with open(readme_path, "r", encoding="utf-8") as f:
 
 setup(
     name="mentat",
-    version=__version__,
+    version="1.0.9",
     python_requires=">=3.10",
     packages=find_packages(
         include=["mentat", "mentat.*", "benchmarks", "benchmarks.*"]

--- a/tests/diff_context_test.py
+++ b/tests/diff_context_test.py
@@ -3,8 +3,8 @@ from pathlib import Path
 
 import pytest
 
+from mentat import Mentat
 from mentat.diff_context import DiffContext
-from mentat.python_client.client import PythonClient
 from mentat.session_context import SESSION_CONTEXT
 
 
@@ -186,8 +186,8 @@ async def test_diff_context_end_to_end(temp_testbed, git_history, mock_call_llm_
     abs_path = Path(temp_testbed) / "multifile_calculator" / "operations.py"
 
     mock_call_llm_api.set_streamed_values([""])
-    python_client = PythonClient(cwd=temp_testbed, paths=[], diff="HEAD~2")
-    await python_client.startup()
+    client = Mentat(cwd=temp_testbed, paths=[], diff="HEAD~2")
+    await client.startup()
 
     session_context = SESSION_CONTEXT.get()
     code_context = session_context.code_context
@@ -200,4 +200,4 @@ async def test_diff_context_end_to_end(temp_testbed, git_history, mock_call_llm_
     assert diff_context.diff_files() == [abs_path]
 
     assert "multifile_calculator" in code_message
-    await python_client.shutdown()
+    await client.shutdown()

--- a/tests/sampler_test.py
+++ b/tests/sampler_test.py
@@ -10,13 +10,13 @@ from openai.types.chat import (
 )
 
 from benchmarks.run_sample import run_sample
+from mentat import Mentat
 from mentat.conversation import MentatAssistantMessageParam
 from mentat.errors import SampleError
 from mentat.git_handler import get_git_diff
 from mentat.parsers.block_parser import BlockParser
 from mentat.parsers.git_parser import GitParser
 from mentat.parsers.parser import ParsedLLMResponse
-from mentat.python_client.client import PythonClient
 from mentat.sampler import __version__
 from mentat.sampler.sample import Sample
 from mentat.sampler.sampler import Sampler
@@ -381,10 +381,10 @@ async def test_sampler_integration(
     )
 
     # Generate a sample using Mentat
-    python_client = PythonClient(cwd=temp_testbed, paths=["."])
-    await python_client.startup()
-    python_client.session.ctx.config.sampler = True
-    await python_client.call_mentat_auto_accept(dedent("""\
+    client = Mentat(cwd=temp_testbed, paths=["."])
+    await client.startup()
+    client.session.ctx.config.sampler = True
+    await client.call_mentat_auto_accept(dedent("""\
         Make the following changes to "multifile_calculator/operations.py":
         1. Add "# Inserted line 2" as the first line
         2. Add "# Replaced Line 2" to the end of the 5th line
@@ -396,15 +396,15 @@ async def test_sampler_integration(
         """))
 
     # Remove all included files; rely on the diff to include them
-    python_client.session.ctx.code_context.include_files = {}
-    await python_client.call_mentat(f"/sample {temp_testbed.as_posix()}")
-    await python_client.call_mentat(merge_base)
-    await python_client.call_mentat("test_url")
-    await python_client.call_mentat("test_title")
-    await python_client.call_mentat("test_description")
-    await python_client.call_mentat("test_test_command")
-    await python_client.call_mentat("q")
-    await python_client.shutdown()
+    client.session.ctx.code_context.include_files = {}
+    await client.call_mentat(f"/sample {temp_testbed.as_posix()}")
+    await client.call_mentat(merge_base)
+    await client.call_mentat("test_url")
+    await client.call_mentat("test_title")
+    await client.call_mentat("test_description")
+    await client.call_mentat("test_test_command")
+    await client.call_mentat("q")
+    await client.shutdown()
 
     # Evaluate the sample using Mentat
     sample_files = list(temp_testbed.glob("sample_*.json"))


### PR DESCRIPTION
You can now import the PythonClient via `from mentat import Mentat`.
* Docs updated
* Comments added to python_client
* tests and benchmarks updated to use new import

## Pull Request Checklist
- [x] Documentation has been updated, or this change doesn't require that
