### PR TITLE
Diff Context never null

### DIFF
--- a/mentat/code_feature.py
+++ b/mentat/code_feature.py
@@ -154,10 +154,7 @@ class CodeFeature:
         if standalone:
             code_message.append("")
 
-        if (
-            code_context.diff_context is not None
-            and self.path in code_context.diff_context.diff_files()
-        ):
+        if self.path in code_context.diff_context.diff_files():
             diff = get_diff_for_file(code_context.diff_context.target, self.path)
             diff_annotations = parse_diff(diff)
             if self.interval.whole_file():

--- a/tests/code_context_test.py
+++ b/tests/code_context_test.py
@@ -210,7 +210,7 @@ async def test_max_auto_tokens(mocker, temp_testbed, mock_session_context):
 
     code_context = CodeContext(
         mock_session_context.stream,
-        mock_session_context.code_context.git_root,
+        mock_session_context.code_context.diff_context.git_root,
     )
     code_context.include("file_1.py")
     mock_session_context.config.auto_context_tokens = 8000

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -24,7 +24,6 @@ from mentat.code_file_manager import CodeFileManager
 from mentat.config import Config, config_file_name
 from mentat.conversation import Conversation
 from mentat.cost_tracker import CostTracker
-from mentat.git_handler import get_git_root_for_path
 from mentat.llm_api_handler import LlmApiHandler
 from mentat.parsers.streaming_printer import StreamingPrinter
 from mentat.sampler.sampler import Sampler
@@ -205,8 +204,6 @@ def mock_session_context(temp_testbed):
     set by a Session if the test creates a Session.
     If you create a Session or Client in your test, do NOT use this SessionContext!
     """
-    git_root = get_git_root_for_path(temp_testbed, raise_error=False)
-
     stream = SessionStream()
 
     cost_tracker = CostTracker()
@@ -215,7 +212,7 @@ def mock_session_context(temp_testbed):
 
     llm_api_handler = LlmApiHandler()
 
-    code_context = CodeContext(stream, git_root)
+    code_context = CodeContext(stream, temp_testbed)
 
     code_file_manager = CodeFileManager()
     conversation = Conversation()

--- a/tests/diff_context_test.py
+++ b/tests/diff_context_test.py
@@ -68,7 +68,8 @@ def test_diff_context_default(temp_testbed, git_history, mock_session_context):
 
     # DiffContext.__init__() (default): active code vs last commit
     diff_context = DiffContext(
-        mock_session_context.stream, mock_session_context.code_context.git_root
+        mock_session_context.stream,
+        temp_testbed,
     )
     assert diff_context.target == "HEAD"
     assert diff_context.name == "HEAD (last commit)"
@@ -99,7 +100,7 @@ async def test_diff_context_commit(temp_testbed, git_history, mock_session_conte
     ).strip()
     diff_context = DiffContext(
         mock_session_context.stream,
-        mock_session_context.code_context.git_root,
+        temp_testbed,
         diff=last_commit,
     )
     assert diff_context.target == last_commit
@@ -119,7 +120,7 @@ async def test_diff_context_commit(temp_testbed, git_history, mock_session_conte
 async def test_diff_context_branch(temp_testbed, git_history, mock_session_context):
     diff_context = DiffContext(
         mock_session_context.stream,
-        mock_session_context.code_context.git_root,
+        temp_testbed,
         diff="test_branch",
     )
     abs_path = Path(temp_testbed) / "multifile_calculator" / "operations.py"
@@ -142,7 +143,7 @@ async def test_diff_context_branch(temp_testbed, git_history, mock_session_conte
 async def test_diff_context_relative(temp_testbed, git_history, mock_session_context):
     diff_context = DiffContext(
         mock_session_context.stream,
-        mock_session_context.code_context.git_root,
+        temp_testbed,
         diff="HEAD~2",
     )
     abs_path = Path(temp_testbed) / "multifile_calculator" / "operations.py"
@@ -168,7 +169,7 @@ async def test_diff_context_pr(temp_testbed, git_history, mock_session_context):
     subprocess.run(["git", "checkout", "test_branch"], cwd=temp_testbed)
     diff_context = DiffContext(
         mock_session_context.stream,
-        mock_session_context.code_context.git_root,
+        temp_testbed,
         pr_diff="master",
     )
 


### PR DESCRIPTION
When run in a non git directory the diff context was set to null which made interacting with it complex. Now the diff context is responsible for determining it is not in a git context and returning sensible empty/none types when called.

## Pull Request Checklist
- [x] Documentation has been updated, or this change doesn't require that
