### PR TITLE
Fix Github Actions ctags install issue

### DIFF
--- a/.github/workflows/lint_and_test.yml
+++ b/.github/workflows/lint_and_test.yml
@@ -1,6 +1,7 @@
 # This workflow will install Python dependencies, run tests and lint with a variety of Python versions
 # For more information see: https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-python
 
+
 name: lint and test
 
 on: [push, pull_request]

--- a/.github/workflows/lint_and_test.yml
+++ b/.github/workflows/lint_and_test.yml
@@ -1,7 +1,6 @@
 # This workflow will install Python dependencies, run tests and lint with a variety of Python versions
 # For more information see: https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-python
 
-
 name: lint and test
 
 on: [push, pull_request]
@@ -27,7 +26,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, windows-latest, macos-latest]
+        os: [ubuntu-latest, windows-latest, macos-13]
         python-version: ["3.10", "3.11"]
 
     steps:

--- a/.github/workflows/lint_and_test.yml
+++ b/.github/workflows/lint_and_test.yml
@@ -26,7 +26,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, windows-latest, macos-13]
+        os: [ubuntu-latest, windows-latest, macos-14]
         python-version: ["3.10", "3.11"]
 
     steps:


### PR DESCRIPTION
ctags installs were failing on github actions macos runners. Switching from `macos-latest` to `macos-14` seems to fix it (although I thought 14 was the latest??)

more details here: https://github.com/actions/runner-images/issues/4020

## Pull Request Checklist
- [x] Documentation has been updated, or this change doesn't require that
