### PR TITLE
Require latest spice and ragdaemon

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -17,12 +17,12 @@ pytest-mock==3.11.1
 pytest-reportlog==0.4.0
 pytest-timeout==2.2.0
 python-dotenv==1.0.0
-ragdaemon==0.1.5
+ragdaemon~=0.1.0
 selenium==4.15.2
 sentry-sdk==1.34.0
 sounddevice==0.4.6
 soundfile==0.12.1
-spiceai==0.1.11
+spiceai~=0.1.0
 termcolor==2.3.0
 textual==0.47.1
 textual-autocomplete==2.1.0b0


### PR DESCRIPTION
use `~=0.1.x` to always fetch latest minor version of spiceai and ragdaemon.

## Pull Request Checklist
- [ ] Documentation has been updated, or this change doesn't require that
