### PR TITLE
pin ragdaemon to the last 0.2.x version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -9,7 +9,7 @@ openai==1.13.3
 pillow==10.1.0
 prompt-toolkit==3.0.39
 Pygments==2.15.1
-ragdaemon~=0.2.0
+ragdaemon==0.2.12
 selenium==4.15.2
 sentry-sdk==1.34.0
 sounddevice==0.4.6


### PR DESCRIPTION
CI was failing. Looks like it was last run with ragdaemon 0.2.7. We got up to 0.2.12 and then recently switched to 0.3.0. Here I pin the version to 0.2.12 to keep it steady. If we start developing mentat again, we can bump it up.

## Pull Request Checklist
- [ ] Documentation has been updated, or this change doesn't require that
